### PR TITLE
Update the editor to output a special __function:__ token for handlers, parse that token in the FlowManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to **Pipecat Flows** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2024-12-08
+
+### Changed
+
+- Fixed function handler registration in FlowManager to handle `__function__:` tokens
+  - Previously, the handler string was used directly, causing "not callable" errors
+  - Now correctly looks up and uses the actual function object from the main module
+  - Supports both direct function references and function names exported from the Flows editor
+
 ## [0.0.8] - 2024-12-07
 
 ### Changed

--- a/editor/examples/food_ordering.json
+++ b/editor/examples/food_ordering.json
@@ -47,7 +47,7 @@
           "type": "function",
           "function": {
             "name": "select_pizza_order",
-            "handler": "select_pizza_order",
+            "handler": "__function__:select_pizza_order",
             "description": "Record the pizza order details",
             "parameters": {
               "type": "object",
@@ -93,7 +93,7 @@
           "type": "function",
           "function": {
             "name": "select_sushi_order",
-            "handler": "select_sushi_order",
+            "handler": "__function__:select_sushi_order",
             "description": "Record the sushi order details",
             "parameters": {
               "type": "object",

--- a/editor/examples/movie_explorer.json
+++ b/editor/examples/movie_explorer.json
@@ -13,7 +13,7 @@
           "type": "function",
           "function": {
             "name": "get_current_movies",
-            "handler": "get_movies",
+            "handler": "__function__:get_movies",
             "description": "Fetch movies currently playing in theaters",
             "parameters": {
               "type": "object",
@@ -26,7 +26,7 @@
           "type": "function",
           "function": {
             "name": "get_upcoming_movies",
-            "handler": "get_upcoming_movies",
+            "handler": "__function__:get_upcoming_movies",
             "description": "Fetch movies coming soon to theaters",
             "parameters": {
               "type": "object",
@@ -49,7 +49,7 @@
           "type": "function",
           "function": {
             "name": "get_movie_details",
-            "handler": "get_movie_details",
+            "handler": "__function__:get_movie_details",
             "description": "Get details about a specific movie including cast",
             "parameters": {
               "type": "object",
@@ -67,7 +67,7 @@
           "type": "function",
           "function": {
             "name": "get_similar_movies",
-            "handler": "get_similar_movies",
+            "handler": "__function__:get_similar_movies",
             "description": "Get similar movies as recommendations",
             "parameters": {
               "type": "object",
@@ -85,7 +85,7 @@
           "type": "function",
           "function": {
             "name": "get_current_movies",
-            "handler": "get_movies",
+            "handler": "__function__:get_movies",
             "description": "Show current movies in theaters",
             "parameters": {
               "type": "object",
@@ -97,7 +97,7 @@
           "type": "function",
           "function": {
             "name": "get_upcoming_movies",
-            "handler": "get_upcoming_movies",
+            "handler": "__function__:get_upcoming_movies",
             "description": "Show movies coming soon",
             "parameters": {
               "type": "object",

--- a/editor/examples/patient_intake.json
+++ b/editor/examples/patient_intake.json
@@ -13,7 +13,7 @@
           "type": "function",
           "function": {
             "name": "verify_birthday",
-            "handler": "verify_birthday",
+            "handler": "__function__:verify_birthday",
             "description": "Verify the user has provided their correct birthday. Once confirmed, the next step is to recording the user's prescriptions.",
             "parameters": {
               "type": "object",
@@ -42,7 +42,7 @@
           "type": "function",
           "function": {
             "name": "record_prescriptions",
-            "handler": "record_prescriptions",
+            "handler": "__function__:record_prescriptions",
             "description": "Record the user's prescriptions. Once confirmed, the next step is to collect allergy information.",
             "parameters": {
               "type": "object",
@@ -84,7 +84,7 @@
           "type": "function",
           "function": {
             "name": "record_allergies",
-            "handler": "record_allergies",
+            "handler": "__function__:record_allergies",
             "description": "Record the user's allergies. Once confirmed, then next step is to collect medical conditions.",
             "parameters": {
               "type": "object",
@@ -122,7 +122,7 @@
           "type": "function",
           "function": {
             "name": "record_conditions",
-            "handler": "record_conditions",
+            "handler": "__function__:record_conditions",
             "description": "Record the user's medical conditions. Once confirmed, the next step is to collect visit reasons.",
             "parameters": {
               "type": "object",
@@ -160,7 +160,7 @@
           "type": "function",
           "function": {
             "name": "record_visit_reasons",
-            "handler": "record_visit_reasons",
+            "handler": "__function__:record_visit_reasons",
             "description": "Record the reasons for their visit. Once confirmed, the next step is to verify all information.",
             "parameters": {
               "type": "object",

--- a/editor/examples/restaurant_reservation.json
+++ b/editor/examples/restaurant_reservation.json
@@ -13,7 +13,7 @@
           "type": "function",
           "function": {
             "name": "record_party_size",
-            "handler": "record_party_size",
+            "handler": "__function__:record_party_size",
             "description": "Record the number of people in the party",
             "parameters": {
               "type": "object",
@@ -43,7 +43,7 @@
           "type": "function",
           "function": {
             "name": "record_time",
-            "handler": "record_time",
+            "handler": "__function__:record_time",
             "description": "Record the requested time",
             "parameters": {
               "type": "object",

--- a/editor/examples/travel_planner.json
+++ b/editor/examples/travel_planner.json
@@ -47,7 +47,7 @@
           "type": "function",
           "function": {
             "name": "select_destination",
-            "handler": "select_destination",
+            "handler": "__function__:select_destination",
             "description": "Record the selected beach destination",
             "parameters": {
               "type": "object",
@@ -77,7 +77,7 @@
           "type": "function",
           "function": {
             "name": "select_destination",
-            "handler": "select_destination",
+            "handler": "__function__:select_destination",
             "description": "Record the selected mountain destination",
             "parameters": {
               "type": "object",
@@ -107,7 +107,7 @@
           "type": "function",
           "function": {
             "name": "record_dates",
-            "handler": "record_dates",
+            "handler": "__function__:record_dates",
             "description": "Record the selected travel dates",
             "parameters": {
               "type": "object",
@@ -142,7 +142,7 @@
           "type": "function",
           "function": {
             "name": "record_activities",
-            "handler": "record_activities",
+            "handler": "__function__:record_activities",
             "description": "Record selected activities",
             "parameters": {
               "type": "object",

--- a/editor/js/utils/export.js
+++ b/editor/js/utils/export.js
@@ -29,6 +29,20 @@ export function generateFlowConfig(graphInstance) {
   }
 
   /**
+   * Adds handler token if needed
+   * @param {Object} functionConfig - Function configuration to process
+   * @param {Object} sourceNode - Node containing the function
+   */
+  function processHandler(functionConfig, sourceNode) {
+    if (sourceNode.properties.function.handler) {
+      const handlerName = sourceNode.properties.function.handler;
+      if (!handlerName.startsWith("__function__:")) {
+        functionConfig.function.handler = `__function__:${handlerName}`;
+      }
+    }
+  }
+
+  /**
    * Finds all functions connected to a node
    * @param {LGraphNode} node - The node to find functions for
    * @returns {Array<Object>} Array of function configurations
@@ -50,6 +64,8 @@ export function generateFlowConfig(graphInstance) {
             type: "function",
             function: { ...targetNode.properties.function },
           };
+
+          processHandler(funcConfig, targetNode);
 
           // Find where this function connects to (if anywhere)
           const functionTargets = targetNode.outputs[0].links || [];
@@ -110,13 +126,16 @@ export function generateFlowConfig(graphInstance) {
 
           // Add all functions with their transition to the final target
           connectedFunctions.forEach((funcNode) => {
-            functions.push({
+            const funcConfig = {
               type: "function",
               function: {
                 ...funcNode.properties.function,
                 transition_to: finalNode.title,
               },
-            });
+            };
+
+            processHandler(funcConfig, funcNode);
+            functions.push(funcConfig);
           });
         }
       });


### PR DESCRIPTION
The Flows editor exports JSON, which will export function handlers as strings. To get this JSON to be runnable, we're adding a `__function__:` token to the handler, so the FlowManager can parse and register the function from the JSON. This is additive, as directly specifying the function name in the JSON is still supported.

This also comes with an update to the editor code to support adding the `__function__:` token. Updated the examples to reflect that change too.