### PR TITLE
Bumping pipecat-ai dependency version to get Gemini fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio",
 ]
 dependencies = [
-    "pipecat-ai>=0.0.49",
+    "pipecat-ai>=0.0.50",
     "loguru~=0.7.2",
 ]
 


### PR DESCRIPTION
`pipecat-ai` 0.0.50 contains important Gemini fixes to work with Gemini 1.5 and Gemini 2.0. Bumping the dependency version for `pipecat-ai` to >=0.0.50.