### PR TITLE
Update FlowManager to support role and task messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- New `initial_system_message` field in `FlowConfig`, which allows setting a
-  global system message for static flows.
-
 ### Changed
 
+- Nodes now have two message types to better delineate defining the role or
+  persona of the bot from the task it needs to accomplish. The message types are:
+
+  - `role_message`, which defines the personality or role of the bot
+  - `task_message`, which defines the task to be completed for a given node
+
+- `role_messages` can be defined for the initial node and then inherited by
+  subsequent nodes. You can treat this as an LLM "system" message.
+
 - Simplified FlowManager initialization by removing the need for manual context
-  setup in static flows.
-- Updated static examples to use the updated API.
+  setup in both static and dynamic flows. Now, you need to create a `FlowManager`
+  and initialize it to start the flow.
+- All examples have been updated to align with the API changes.
 
 ## [0.0.9] - 2024-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nodes now have two message types to better delineate defining the role or
   persona of the bot from the task it needs to accomplish. The message types are:
 
-  - `role_message`, which defines the personality or role of the bot
-  - `task_message`, which defines the task to be completed for a given node
+  - `role_messages`, which defines the personality or role of the bot
+  - `task_messages`, which defines the task to be completed for a given node
 
 - `role_messages` can be defined for the initial node and then inherited by
   subsequent nodes. You can treat this as an LLM "system" message.

--- a/editor/examples/food_ordering.json
+++ b/editor/examples/food_ordering.json
@@ -2,7 +2,13 @@
   "initial_node": "start",
   "nodes": {
     "start": {
-      "messages": [
+      "role_messages": [
+        {
+          "role": "system",
+          "content": "You are an order-taking assistant. You must ALWAYS use the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Keep the conversation friendly, casual, and polite. Avoid outputting special characters and emojis."
+        }
+      ],
+      "task_messages": [
         {
           "role": "system",
           "content": "For this step, ask the user if they want pizza or sushi, and wait for them to use a function to choose. Start off by greeting them. Be friendly and casual; you're taking an order for food over the phone."
@@ -36,7 +42,7 @@
       ]
     },
     "choose_pizza": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "You are handling a pizza order. Use the available functions:\n\n- Use select_pizza_order when the user specifies both size AND type\n\n- Use confirm_order when the user confirms they are satisfied with their selection\n\nPricing:\n\n- Small: $10\n\n- Medium: $15\n\n- Large: $20\n\nAfter selection, confirm both the size and type, state the price, and ask if they want to confirm their order. Remember to be friendly and casual."
@@ -82,7 +88,7 @@
       ]
     },
     "choose_sushi": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "You are handling a sushi order. Use the available functions:\n\n- Use select_sushi_order when the user specifies both count AND type\n\n- Use confirm_order when the user confirms they are satisfied with their selection\n\nPricing:\n\n- $8 per roll\n\nAfter selection, confirm both the count and type, state the price, and ask if they want to confirm their order. Remember to be friendly and casual."
@@ -129,7 +135,7 @@
       ]
     },
     "confirm": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Read back the complete order details to the user and ask for final confirmation. Use the available functions:\n\n- Use complete_order when the user confirms\n\n- Use revise_order if they want to change something\n\nBe friendly and clear when reading back the order details."
@@ -151,7 +157,7 @@
       ]
     },
     "end": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Concisely end the conversation—1-3 words is appropriate. Just say 'Bye' or something similarly short."

--- a/editor/examples/movie_explorer.json
+++ b/editor/examples/movie_explorer.json
@@ -2,10 +2,16 @@
   "initial_node": "greeting",
   "nodes": {
     "greeting": {
-      "messages": [
+      "role_messages": [
         {
           "role": "system",
-          "content": "You are a helpful movie expert. Start by greeting the user and asking if they'd like to know about movies currently in theaters or upcoming releases. Wait for their choice before using either get_current_movies or get_upcoming_movies."
+          "content": "You are a friendly movie expert. Your responses will be converted to audio, so avoid special characters. Always use the available functions to progress the conversation naturally."
+        }
+      ],
+      "task_messages": [
+        {
+          "role": "system",
+          "content": "Start by greeting the user and asking if they'd like to know about movies currently in theaters or upcoming releases. Wait for their choice before using either get_current_movies or get_upcoming_movies."
         }
       ],
       "functions": [
@@ -38,7 +44,7 @@
       ]
     },
     "explore_movie": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Help the user learn more about movies. You can:\n\n- Use get_movie_details when they express interest in a specific movie\n\n- Use get_similar_movies to show recommendations\n\n- Use get_current_movies to see what's playing now\n\n- Use get_upcoming_movies to see what's coming soon\n\n- Use end_conversation when they're done exploring\n\nAfter showing details or recommendations, ask if they'd like to explore another movie or end the conversation."
@@ -120,7 +126,7 @@
       ]
     },
     "end": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Thank the user warmly and mention they can return anytime to discover more movies."

--- a/editor/examples/patient_intake.json
+++ b/editor/examples/patient_intake.json
@@ -2,7 +2,13 @@
   "initial_node": "start",
   "nodes": {
     "start": {
-      "messages": [
+      "role_messages": [
+        {
+          "role": "system",
+          "content": "You are Jessica, an agent for Tri-County Health Services. You must ALWAYS use one of the available functions to progress the conversation. Be professional but friendly."
+        }
+      ],
+      "task_messages": [
         {
           "role": "system",
           "content": "Start by introducing yourself to Chad Bailey, then ask for their date of birth, including the year. Once they provide their birthday, use verify_birthday to check it. If verified (1983-01-01), proceed to prescriptions."
@@ -31,7 +37,7 @@
       ]
     },
     "get_prescriptions": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "This step is for collecting prescriptions. Ask them what prescriptions they're taking, including the dosage. After recording prescriptions (or confirming none), proceed to allergies."
@@ -73,7 +79,7 @@
       ]
     },
     "get_allergies": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Collect allergy information. Ask about any allergies they have. After recording allergies (or confirming none), proceed to medical conditions."
@@ -111,7 +117,7 @@
       ]
     },
     "get_conditions": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Collect medical condition information. Ask about any medical conditions they have. After recording conditions (or confirming none), proceed to visit reasons."
@@ -149,7 +155,7 @@
       ]
     },
     "get_visit_reasons": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Collect information about the reason for their visit. Ask what brings them to the doctor today. After recording their reasons, proceed to verification."
@@ -187,7 +193,7 @@
       ]
     },
     "verify": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Review all collected information with the patient. Follow these steps:\n\n1. Summarize their prescriptions, allergies, conditions, and visit reasons\n\n2. Ask if everything is correct\n\n3. Use the appropriate function based on their response\n\nBe thorough in reviewing all details and wait for explicit confirmation."
@@ -221,7 +227,7 @@
       ]
     },
     "confirm": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Once confirmed, thank them, then use the complete_intake function to end the conversation."
@@ -243,7 +249,7 @@
       ]
     },
     "end": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Thank them for their time and end the conversation."

--- a/editor/examples/restaurant_reservation.json
+++ b/editor/examples/restaurant_reservation.json
@@ -2,7 +2,13 @@
   "initial_node": "start",
   "nodes": {
     "start": {
-      "messages": [
+      "role_messages": [
+        {
+          "role": "system",
+          "content": "You are a restaurant reservation assistant for La Maison, an upscale French restaurant. You must ALWAYS use one of the available functions to progress the conversation. This is a phone conversations and your responses will be converted to audio. Avoid outputting special characters and emojis. Be causal and friendly."
+        }
+      ],
+      "task_messages": [
         {
           "role": "system",
           "content": "Warmly greet the customer and ask how many people are in their party."
@@ -32,7 +38,7 @@
       ]
     },
     "get_time": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Ask what time they'd like to dine. Restaurant is open 5 PM to 10 PM. After they provide a time, confirm it's within operating hours before recording. Use 24-hour format for internal recording (e.g., 17:00 for 5 PM)."
@@ -62,7 +68,7 @@
       ]
     },
     "confirm": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Confirm the reservation details and end the conversation."
@@ -84,7 +90,7 @@
       ]
     },
     "end": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Thank them and end the conversation."

--- a/editor/examples/travel_planner.json
+++ b/editor/examples/travel_planner.json
@@ -2,7 +2,13 @@
   "initial_node": "start",
   "nodes": {
     "start": {
-      "messages": [
+      "role_messages": [
+        {
+          "role": "system",
+          "content": "You are a travel planning assistant with Summit & Sand Getaways. You must ALWAYS use one of the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Avoid outputting special characters and emojis."
+        }
+      ],
+      "task_messages": [
         {
           "role": "system",
           "content": "For this step, ask if they're interested in planning a beach vacation or a mountain retreat, and wait for them to choose. Start with an enthusiastic greeting and be conversational; you're helping them plan their dream vacation."
@@ -36,7 +42,7 @@
       ]
     },
     "choose_beach": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "You are handling beach vacation planning. Use the available functions:\n - Use select_destination when the user chooses their preferred beach location\n - After destination is selected, dates will be collected automatically\n\nAvailable beach destinations are: 'Maui', 'Cancun', or 'Maldives'. After they choose, confirm their selection. Be enthusiastic and paint a picture of each destination."
@@ -66,7 +72,7 @@
       ]
     },
     "choose_mountain": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "You are handling mountain retreat planning. Use the available functions:\n - Use select_destination when the user chooses their preferred mountain location\n - After destination is selected, dates will be collected automatically\n\nAvailable mountain destinations are: 'Swiss Alps', 'Rocky Mountains', or 'Himalayas'. After they choose, confirm their selection. Be enthusiastic and paint a picture of each destination."
@@ -96,7 +102,7 @@
       ]
     },
     "get_dates": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Handle travel date selection. Use the available functions:\n - Use record_dates when the user specifies their travel dates (can be used multiple times if they change their mind)\n - After dates are recorded, activities will be collected automatically\n\nAsk for their preferred travel dates within the next 6 months. After recording dates, confirm the selection."
@@ -131,7 +137,7 @@
       ]
     },
     "get_activities": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Handle activity preferences. Use the available functions:\n - Use record_activities to save their activity preferences\n - After activities are recorded, verification will happen automatically\n\nFor beach destinations, suggest: snorkeling, surfing, sunset cruise\nFor mountain destinations, suggest: hiking, skiing, mountain biking\n\nAfter they choose, confirm their selections."
@@ -165,7 +171,7 @@
       ]
     },
     "verify_itinerary": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Review the complete itinerary with the user. Summarize their destination, dates, and chosen activities. Use revise_plan to make changes or confirm_booking if they're happy. Be thorough in reviewing all details and ask for their confirmation."
@@ -199,7 +205,7 @@
       ]
     },
     "confirm_booking": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "The booking is confirmed. Share some relevant tips about their chosen destination, thank them warmly, and use end to complete the conversation."
@@ -227,7 +233,7 @@
       ]
     },
     "end": {
-      "messages": [
+      "task_messages": [
         {
           "role": "system",
           "content": "Wish them a wonderful trip and end the conversation."

--- a/editor/index.html
+++ b/editor/index.html
@@ -49,13 +49,24 @@ SPDX-License-Identifier: BSD 2-Clause License
           <div class="editor-content hidden space-y-4">
             <!-- Message Editor Section -->
             <div class="message-editor">
-              <!-- Message Input -->
-              <div class="form-control">
+              <!-- Role Messages Input (hidden by default) -->
+              <div id="role-messages-container" class="form-control w-full" style="display: none;">
                 <label class="label">
-                  <span class="label-text">Message</span>
+                  <span class="label-text">Role Messages</span>
+                  <span class="label-text-alt text-base-content/60">Define bot's personality</span>
                 </label>
-                <textarea id="message-editor"
-                  class="textarea textarea-bordered font-mono text-xs h-[calc(50vh-200px)]"></textarea>
+                <textarea id="role-messages-editor"
+                  class="textarea textarea-bordered font-mono text-xs h-[calc(25vh-100px)] w-full"></textarea>
+              </div>
+
+              <!-- Task Messages Input -->
+              <div class="form-control mt-4">
+                <label class="label">
+                  <span class="label-text">Task Messages</span>
+                  <span class="label-text-alt text-base-content/60">Define node's task</span>
+                </label>
+                <textarea id="task-messages-editor"
+                  class="textarea textarea-bordered font-mono text-xs h-[calc(25vh-100px)]"></textarea>
               </div>
 
               <!-- Pre-actions Input -->

--- a/editor/js/nodes/endNode.js
+++ b/editor/js/nodes/endNode.js
@@ -16,11 +16,23 @@ export class PipecatEndNode extends PipecatBaseNode {
    * Creates a new end node
    */
   constructor() {
-    super("End Node", "#e74c3c", "Enter final message...");
+    super("End Node", "#e74c3c");
     this.addInput("In", "flow", {
       multipleConnections: true,
       linkType: LiteGraph.MULTIPLE_LINK,
     });
+
+    // Initialize with only task messages for the end node
+    this.properties = {
+      task_messages: [
+        {
+          role: "system",
+          content: "Enter final task message...",
+        },
+      ],
+      pre_actions: [],
+      post_actions: [],
+    };
   }
 
   /**

--- a/editor/js/nodes/flowNode.js
+++ b/editor/js/nodes/flowNode.js
@@ -15,8 +15,20 @@ export class PipecatFlowNode extends PipecatBaseNode {
    * Creates a new flow node
    */
   constructor() {
-    super("Flow Node", "#3498db", "Enter message content...");
+    super("Flow Node", "#3498db");
     this.addInput("In", "flow");
     this.addOutput("Out", "flow");
+
+    // Initialize with only task messages since role is inherited
+    this.properties = {
+      task_messages: [
+        {
+          role: "system",
+          content: "Enter task message...",
+        },
+      ],
+      pre_actions: [],
+      post_actions: [],
+    };
   }
 }

--- a/editor/js/nodes/startNode.js
+++ b/editor/js/nodes/startNode.js
@@ -16,7 +16,25 @@ export class PipecatStartNode extends PipecatBaseNode {
    * @param {string} [title="Start"] - Optional custom title for the node
    */
   constructor(title = "Start") {
-    super(title, "#2ecc71", "Enter initial system message...");
+    super(title, "#2ecc71");
     this.addOutput("Out", "flow");
+
+    // Initialize with both role and task messages for the start node
+    this.properties = {
+      role_messages: [
+        {
+          role: "system",
+          content: "Enter bot's personality/role...",
+        },
+      ],
+      task_messages: [
+        {
+          role: "system",
+          content: "Enter initial task...",
+        },
+      ],
+      pre_actions: [],
+      post_actions: [],
+    };
   }
 }

--- a/editor/js/types.js
+++ b/editor/js/types.js
@@ -14,7 +14,8 @@
 
 /**
  * @typedef {Object} NodeConfig
- * @property {Array<Message>} messages
+ * @property {Array<Message>} [role_messages] - Optional messages defining bot's role/personality
+ * @property {Array<Message>} task_messages - Required messages defining the node's task
  * @property {Array<Function>} functions
  * @property {Array<Action>} [pre_actions]
  * @property {Array<Action>} [post_actions]
@@ -43,4 +44,5 @@
  * @property {string} name
  * @property {string} description
  * @property {Object} parameters
+ * @property {string} [transition_to]
  */

--- a/editor/js/utils/export.js
+++ b/editor/js/utils/export.js
@@ -159,18 +159,27 @@ export function generateFlowConfig(graphInstance) {
       return;
     }
 
-    // Use node.title directly as the node ID
-    flowConfig.nodes[node.title] = {
-      messages: node.properties.messages,
+    // Create node configuration with new message structure
+    const nodeConfig = {
+      task_messages: node.properties.task_messages,
       functions: findConnectedFunctions(node),
     };
 
+    // Add role_messages if present
+    if (node.properties.role_messages?.length > 0) {
+      nodeConfig.role_messages = node.properties.role_messages;
+    }
+
+    // Add actions if present
     if (node.properties.pre_actions?.length > 0) {
-      flowConfig.nodes[node.title].pre_actions = node.properties.pre_actions;
+      nodeConfig.pre_actions = node.properties.pre_actions;
     }
     if (node.properties.post_actions?.length > 0) {
-      flowConfig.nodes[node.title].post_actions = node.properties.post_actions;
+      nodeConfig.post_actions = node.properties.post_actions;
     }
+
+    // Use node.title as the node ID
+    flowConfig.nodes[node.title] = nodeConfig;
   });
 
   return flowConfig;

--- a/editor/js/utils/import.js
+++ b/editor/js/utils/import.js
@@ -59,10 +59,14 @@ export function createFlowFromConfig(graph, flowConfig) {
 
     // Set node properties
     node.properties = {
-      messages: nodeConfig.messages,
+      task_messages: nodeConfig.task_messages,
       pre_actions: nodeConfig.pre_actions || [],
       post_actions: nodeConfig.post_actions || [],
     };
+
+    if (nodeConfig.role_messages?.length > 0) {
+      node.properties.role_messages = nodeConfig.role_messages;
+    }
 
     graph.add(node);
     nodes[nodeId] = { node, config: nodeConfig };

--- a/examples/dynamic/insurance_anthropic.py
+++ b/examples/dynamic/insurance_anthropic.py
@@ -153,7 +153,22 @@ async def end_quote() -> FlowResult:
 def create_initial_node() -> NodeConfig:
     """Create the initial node asking for age."""
     return {
-        "messages": [
+        "role_messages": [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            "You are a friendly insurance agent. Your responses will be "
+                            "converted to audio, so avoid special characters. Always use "
+                            "the available functions to progress the conversation naturally."
+                        ),
+                    }
+                ],
+            }
+        ],
+        "task_messages": [
             {
                 "role": "user",
                 "content": [
@@ -186,7 +201,7 @@ def create_initial_node() -> NodeConfig:
 def create_marital_status_node() -> NodeConfig:
     """Create node for collecting marital status."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "user",
                 "content": [
@@ -217,7 +232,7 @@ def create_marital_status_node() -> NodeConfig:
 def create_quote_calculation_node(age: int, marital_status: str) -> NodeConfig:
     """Create node for calculating initial quote."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "user",
                 "content": [
@@ -255,7 +270,7 @@ def create_quote_results_node(
 ) -> NodeConfig:
     """Create node for showing quote and adjustment options."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "user",
                 "content": [
@@ -301,7 +316,7 @@ def create_quote_results_node(
 def create_end_node() -> NodeConfig:
     """Create the final node."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "user",
                 "content": [
@@ -385,24 +400,7 @@ async def main():
             api_key=os.getenv("ANTHROPIC_API_KEY"), model="claude-3-5-sonnet-latest"
         )
 
-        # Create initial context
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": (
-                            "You are a friendly insurance agent. Your responses will be "
-                            "converted to audio, so avoid special characters. Always use "
-                            "the available functions to progress the conversation naturally."
-                        ),
-                    }
-                ],
-            }
-        ]
-
-        context = OpenAILLMContext(messages, [])
+        context = OpenAILLMContext()
         context_aggregator = llm.create_context_aggregator(context)
 
         # Create pipeline
@@ -429,7 +427,7 @@ async def main():
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             # Initialize flow
-            await flow_manager.initialize(messages)
+            await flow_manager.initialize()
             # Set initial node
             await flow_manager.set_node("initial", create_initial_node())
             await task.queue_frames([context_aggregator.user().get_context_frame()])

--- a/examples/dynamic/insurance_gemini.py
+++ b/examples/dynamic/insurance_gemini.py
@@ -172,17 +172,18 @@ def create_initial_node() -> NodeConfig:
         ],
         "functions": [
             {
-                "type": "function",
-                "function": {
-                    "name": "collect_age",
-                    "handler": collect_age,
-                    "description": "Record customer's age",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {"age": {"type": "integer"}},
-                        "required": ["age"],
-                    },
-                },
+                "function_declarations": [
+                    {
+                        "name": "collect_age",
+                        "handler": collect_age,
+                        "description": "Record customer's age",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"age": {"type": "integer"}},
+                            "required": ["age"],
+                        },
+                    }
+                ]
             }
         ],
     }

--- a/examples/dynamic/insurance_gemini.py
+++ b/examples/dynamic/insurance_gemini.py
@@ -220,7 +220,6 @@ def create_marital_status_node() -> NodeConfig:
                 ]
             }
         ],
-        "pre_actions": [{"type": "tts_say", "text": "Now, I'll need to know your marital status."}],
     }
 
 
@@ -323,46 +322,50 @@ def create_end_node() -> NodeConfig:
             }
         ],
         "functions": [],
-        "pre_actions": [
-            {"type": "tts_say", "text": "Thank you for getting a quote with us today!"}
-        ],
         "post_actions": [{"type": "end_conversation"}],
     }
 
 
-# Transition callback
+# Transition callbacks and handlers
+async def handle_age_collection(args: Dict, flow_manager: FlowManager):
+    flow_manager.state["age"] = args["age"]
+    await flow_manager.set_node("marital_status", create_marital_status_node())
+
+async def handle_marital_status_collection(args: Dict, flow_manager: FlowManager):
+    flow_manager.state["marital_status"] = args["marital_status"]
+    await flow_manager.set_node(
+        "quote_calculation",
+        create_quote_calculation_node(
+            flow_manager.state["age"], 
+            flow_manager.state["marital_status"]
+        ),
+    )
+
+async def handle_quote_calculation(args: Dict, flow_manager: FlowManager):
+    quote = await calculate_quote(args)
+    flow_manager.state["quote"] = quote
+    await flow_manager.set_node("quote_results", create_quote_results_node(quote))
+
+async def handle_coverage_update(args: Dict, flow_manager: FlowManager):
+    updated_quote = await update_coverage(args)
+    flow_manager.state["quote"] = updated_quote
+    await flow_manager.set_node("quote_results", create_quote_results_node(updated_quote))
+
+async def handle_end_quote(_: Dict, flow_manager: FlowManager):
+    await flow_manager.set_node("end", create_end_node())
+
+HANDLERS = {
+    "collect_age": handle_age_collection,
+    "collect_marital_status": handle_marital_status_collection,
+    "calculate_quote": handle_quote_calculation,
+    "update_coverage": handle_coverage_update,
+    "end_quote": handle_end_quote,
+}
+
 async def handle_insurance_transition(function_name: str, args: Dict, flow_manager: FlowManager):
     """Handle transitions between insurance flow states."""
-    logger.debug(f"Handling transition for function: {function_name} with args: {args}")
-
-    if function_name == "collect_age":
-        flow_manager.state["age"] = args["age"]
-        await flow_manager.set_node("marital_status", create_marital_status_node())
-
-    elif function_name == "collect_marital_status":
-        flow_manager.state["marital_status"] = args["marital_status"]
-        await flow_manager.set_node(
-            "quote_calculation",
-            create_quote_calculation_node(
-                flow_manager.state["age"], flow_manager.state["marital_status"]
-            ),
-        )
-
-    elif function_name == "calculate_quote":
-        # Calculate the quote using the handler
-        quote = await calculate_quote(args)
-        flow_manager.state["quote"] = quote
-        await flow_manager.set_node("quote_results", create_quote_results_node(quote))
-
-    elif function_name == "update_coverage":
-        # Calculate updated quote using the handler
-        updated_quote = await update_coverage(args)
-        flow_manager.state["quote"] = updated_quote
-        await flow_manager.set_node("quote_results", create_quote_results_node(updated_quote))
-
-    elif function_name == "end_quote":
-        await flow_manager.set_node("end", create_end_node())
-
+    logger.debug(f"Processing {function_name} transition with args: {args}")
+    await HANDLERS[function_name](args, flow_manager)
 
 async def main():
     """Main function to set up and run the insurance quote bot."""

--- a/examples/dynamic/insurance_openai.py
+++ b/examples/dynamic/insurance_openai.py
@@ -213,7 +213,6 @@ def create_marital_status_node() -> NodeConfig:
                 },
             }
         ],
-        "pre_actions": [{"type": "tts_say", "text": "Now, I'll need to know your marital status."}],
     }
 
 
@@ -316,59 +315,50 @@ def create_end_node() -> NodeConfig:
             }
         ],
         "functions": [],
-        "pre_actions": [
-            {"type": "tts_say", "text": "Thank you for getting a quote with us today!"}
-        ],
         "post_actions": [{"type": "end_conversation"}],
     }
 
 
-# Transition callback
+# Transition callbacks and handlers
+async def handle_age_collection(args: Dict, flow_manager: FlowManager):
+    flow_manager.state["age"] = args["age"]
+    await flow_manager.set_node("marital_status", create_marital_status_node())
+
+async def handle_marital_status_collection(args: Dict, flow_manager: FlowManager):
+    flow_manager.state["marital_status"] = args["marital_status"]
+    await flow_manager.set_node(
+        "quote_calculation",
+        create_quote_calculation_node(
+            flow_manager.state["age"], 
+            flow_manager.state["marital_status"]
+        ),
+    )
+
+async def handle_quote_calculation(args: Dict, flow_manager: FlowManager):
+    quote = await calculate_quote(args)
+    flow_manager.state["quote"] = quote
+    await flow_manager.set_node("quote_results", create_quote_results_node(quote))
+
+async def handle_coverage_update(args: Dict, flow_manager: FlowManager):
+    updated_quote = await update_coverage(args)
+    flow_manager.state["quote"] = updated_quote
+    await flow_manager.set_node("quote_results", create_quote_results_node(updated_quote))
+
+async def handle_end_quote(_: Dict, flow_manager: FlowManager):
+    await flow_manager.set_node("end", create_end_node())
+
+HANDLERS = {
+    "collect_age": handle_age_collection,
+    "collect_marital_status": handle_marital_status_collection,
+    "calculate_quote": handle_quote_calculation,
+    "update_coverage": handle_coverage_update,
+    "end_quote": handle_end_quote,
+}
+
 async def handle_insurance_transition(function_name: str, args: Dict, flow_manager: FlowManager):
     """Handle transitions between insurance flow states."""
-    logger.debug(f"Transition callback executing for function: {function_name} with args: {args}")
-
-    if function_name == "collect_age":
-        logger.debug("Processing collect_age transition")
-        flow_manager.state["age"] = args["age"]
-        await flow_manager.set_node("marital_status", create_marital_status_node())
-        logger.debug("Completed collect_age transition")
-
-    elif function_name == "collect_marital_status":
-        logger.debug("Processing collect_marital_status transition")
-        flow_manager.state["marital_status"] = args["marital_status"]
-        await flow_manager.set_node(
-            "quote_calculation",
-            create_quote_calculation_node(
-                flow_manager.state["age"], flow_manager.state["marital_status"]
-            ),
-        )
-        logger.debug("Completed collect_marital_status transition")
-
-    elif function_name == "calculate_quote":
-        logger.debug("Processing calculate_quote transition")
-        quote = await calculate_quote(args)
-        flow_manager.state["quote"] = quote
-        await flow_manager.set_node(
-            "quote_results",
-            create_quote_results_node(quote),
-        )
-        logger.debug("Completed calculate_quote transition")
-
-    elif function_name == "update_coverage":
-        logger.debug("Processing update_coverage transition")
-        updated_quote = await update_coverage(args)
-        flow_manager.state["quote"] = updated_quote
-        await flow_manager.set_node(
-            "quote_results",
-            create_quote_results_node(updated_quote),
-        )
-        logger.debug("Completed update_coverage transition")
-
-    elif function_name == "end_quote":
-        logger.debug("Processing end_quote transition")
-        await flow_manager.set_node("end", create_end_node())
-        logger.debug("Completed end_quote transition")
+    logger.debug(f"Processing {function_name} transition with args: {args}")
+    await HANDLERS[function_name](args, flow_manager)
 
 
 async def main():

--- a/examples/dynamic/insurance_openai.py
+++ b/examples/dynamic/insurance_openai.py
@@ -153,7 +153,17 @@ async def end_quote() -> FlowResult:
 def create_initial_node() -> NodeConfig:
     """Create the initial node asking for age."""
     return {
-        "messages": [
+        "role_messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a friendly insurance agent. Your responses will be "
+                    "converted to audio, so avoid special characters. Always use "
+                    "the available functions to progress the conversation naturally."
+                ),
+            }
+        ],
+        "task_messages": [
             {
                 "role": "system",
                 "content": "Start by asking for the customer's age.",
@@ -180,7 +190,7 @@ def create_initial_node() -> NodeConfig:
 def create_marital_status_node() -> NodeConfig:
     """Create node for collecting marital status."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "system",
                 "content": "Ask about the customer's marital status for premium calculation.",
@@ -210,7 +220,7 @@ def create_marital_status_node() -> NodeConfig:
 def create_quote_calculation_node(age: int, marital_status: str) -> NodeConfig:
     """Create node for calculating initial quote."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "system",
                 "content": (
@@ -249,7 +259,7 @@ def create_quote_results_node(
 ) -> NodeConfig:
     """Create node for showing quote and adjustment options."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "system",
                 "content": (
@@ -296,7 +306,7 @@ def create_quote_results_node(
 def create_end_node() -> NodeConfig:
     """Create the final node."""
     return {
-        "messages": [
+        "task_messages": [
             {
                 "role": "system",
                 "content": (
@@ -383,19 +393,7 @@ async def main():
         tts = DeepgramTTSService(api_key=os.getenv("DEEPGRAM_API_KEY"), voice="aura-helios-en")
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")
 
-        # Create initial context
-        messages = [
-            {
-                "role": "system",
-                "content": (
-                    "You are a friendly insurance agent. Your responses will be "
-                    "converted to audio, so avoid special characters. Always use "
-                    "the available functions to progress the conversation naturally."
-                ),
-            }
-        ]
-
-        context = OpenAILLMContext(messages, [])
+        context = OpenAILLMContext()
         context_aggregator = llm.create_context_aggregator(context)
 
         # Create pipeline
@@ -422,7 +420,7 @@ async def main():
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             logger.debug("Initializing flow")
-            await flow_manager.initialize(messages)
+            await flow_manager.initialize()
             logger.debug("Setting initial node")
             await flow_manager.set_node("initial", create_initial_node())
             logger.debug("Queueing initial context")

--- a/examples/static/food_ordering.py
+++ b/examples/static/food_ordering.py
@@ -110,15 +110,15 @@ async def select_sushi_order(args: FlowArgs) -> SushiOrderResult:
 
 flow_config: FlowConfig = {
     "initial_node": "start",
-    "initial_system_message": [
-        {
-            "role": "system",
-            "content": "You are an order-taking assistant. You must ALWAYS use the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Keep the conversation friendly, casual, and polite. Avoid outputting special characters and emojis.",
-        }
-    ],
     "nodes": {
         "start": {
-            "messages": [
+            "role_messages": [
+                {
+                    "role": "system",
+                    "content": "You are an order-taking assistant. You must ALWAYS use the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Keep the conversation friendly, casual, and polite. Avoid outputting special characters and emojis.",
+                }
+            ],
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "For this step, ask the user if they want pizza or sushi, and wait for them to use a function to choose. Start off by greeting them. Be friendly and casual; you're taking an order for food over the phone.",
@@ -146,7 +146,7 @@ flow_config: FlowConfig = {
             ],
         },
         "choose_pizza": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": """You are handling a pizza order. Use the available functions:
@@ -198,7 +198,7 @@ After selection, confirm both the size and type, state the price, and ask if the
             ],
         },
         "choose_sushi": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": """You are handling a sushi order. Use the available functions:
@@ -249,7 +249,7 @@ After selection, confirm both the count and type, state the price, and ask if th
             ],
         },
         "confirm": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": """Read back the complete order details to the user and ask for final confirmation. Use the available functions:
@@ -272,7 +272,7 @@ Be friendly and clear when reading back the order details.""",
             ],
         },
         "end": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Concisely end the conversation—1-3 words is appropriate. Just say 'Bye' or something similarly short.",

--- a/examples/static/movie_explorer_anthropic.py
+++ b/examples/static/movie_explorer_anthropic.py
@@ -300,23 +300,18 @@ async def get_similar_movies(args: FlowArgs) -> Union[SimilarMoviesResult, Error
 # Flow configuration
 flow_config: FlowConfig = {
     "initial_node": "greeting",
-    "initial_system_message": [
-        {
-            "role": "system",
-            "content": "You are a friendly movie expert. Your responses will be converted to audio, so avoid special characters. Always use the available functions to progress the conversation naturally.",
-        }
-    ],
     "nodes": {
         "greeting": {
-            "messages": [
+            "role_messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly movie expert. Your responses will be converted to audio, so avoid special characters. Always use the available functions to progress the conversation naturally.",
+                }
+            ],
+            "task_messages": [
                 {
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": "Start by greeting the user and asking if they'd like to know about movies currently in theaters or upcoming releases. Wait for their choice before using either get_current_movies or get_upcoming_movies.",
-                        }
-                    ],
+                    "content": "Start by greeting the user and asking if they'd like to know about movies currently in theaters or upcoming releases. Wait for their choice before using either get_current_movies or get_upcoming_movies.",
                 }
             ],
             "functions": [
@@ -337,7 +332,7 @@ flow_config: FlowConfig = {
             ],
         },
         "explore_movie": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "user",
                     "content": [
@@ -401,7 +396,7 @@ After showing details or recommendations, ask if they'd like to explore another 
             ],
         },
         "end": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "user",
                     "content": [

--- a/examples/static/movie_explorer_gemini.py
+++ b/examples/static/movie_explorer_gemini.py
@@ -298,15 +298,15 @@ async def get_similar_movies(args: FlowArgs) -> Union[SimilarMoviesResult, Error
 # Flow configuration
 flow_config: FlowConfig = {
     "initial_node": "greeting",
-    "initial_system_message": [
-        {
-            "role": "system",
-            "content": "You are a friendly movie expert. Your responses will be converted to audio, so avoid special characters. Always use the available functions to progress the conversation naturally.",
-        }
-    ],
     "nodes": {
         "greeting": {
-            "messages": [
+            "role_messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly movie expert. Your responses will be converted to audio, so avoid special characters. Always use the available functions to progress the conversation naturally.",
+                }
+            ],
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Start by greeting the user and asking if they'd like to know about movies currently in theaters or upcoming releases. Wait for their choice before using either get_current_movies or get_upcoming_movies.",
@@ -334,7 +334,7 @@ flow_config: FlowConfig = {
             ],
         },
         "explore_movie": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": """Help the user learn more about movies. You can:
@@ -397,7 +397,7 @@ After showing details or recommendations, ask if they'd like to explore another 
             ],
         },
         "end": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Thank the user warmly and mention they can return anytime to discover more movies.",

--- a/examples/static/movie_explorer_openai.py
+++ b/examples/static/movie_explorer_openai.py
@@ -302,15 +302,15 @@ async def get_similar_movies(args: FlowArgs) -> Union[SimilarMoviesResult, Error
 # Flow configuration
 flow_config: FlowConfig = {
     "initial_node": "greeting",
-    "initial_system_message": [
-        {
-            "role": "system",
-            "content": "You are a friendly movie expert. Your responses will be converted to audio, so avoid special characters. Always use the available functions to progress the conversation naturally.",
-        }
-    ],
     "nodes": {
         "greeting": {
-            "messages": [
+            "role_messages": [
+                {
+                    "role": "system",
+                    "content": "You are a friendly movie expert. Your responses will be converted to audio, so avoid special characters. Always use the available functions to progress the conversation naturally.",
+                }
+            ],
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Start by greeting the user and asking if they'd like to know about movies currently in theaters or upcoming releases. Wait for their choice before using either get_current_movies or get_upcoming_movies.",
@@ -340,7 +340,7 @@ flow_config: FlowConfig = {
             ],
         },
         "explore_movie": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": """Help the user learn more about movies. You can:
@@ -414,7 +414,7 @@ After showing details or recommendations, ask if they'd like to explore another 
             ],
         },
         "end": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Thank the user warmly and mention they can return anytime to discover more movies.",

--- a/examples/static/patient_intake.py
+++ b/examples/static/patient_intake.py
@@ -165,15 +165,15 @@ async def record_visit_reasons(args: FlowArgs) -> VisitReasonRecordResult:
 
 flow_config: FlowConfig = {
     "initial_node": "start",
-    "initial_system_message": [
-        {
-            "role": "system",
-            "content": "You are Jessica, an agent for Tri-County Health Services. You must ALWAYS use one of the available functions to progress the conversation. Be professional but friendly.",
-        }
-    ],
     "nodes": {
         "start": {
-            "messages": [
+            "role_messages": [
+                {
+                    "role": "system",
+                    "content": "You are Jessica, an agent for Tri-County Health Services. You must ALWAYS use one of the available functions to progress the conversation. Be professional but friendly.",
+                }
+            ],
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Start by introducing yourself to Chad Bailey, then ask for their date of birth, including the year. Once they provide their birthday, use verify_birthday to check it. If verified (1983-01-01), proceed to prescriptions.",
@@ -202,7 +202,7 @@ flow_config: FlowConfig = {
             ],
         },
         "get_prescriptions": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "This step is for collecting prescriptions. Ask them what prescriptions they're taking, including the dosage. After recording prescriptions (or confirming none), proceed to allergies.",
@@ -244,7 +244,7 @@ flow_config: FlowConfig = {
             ],
         },
         "get_allergies": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Collect allergy information. Ask about any allergies they have. After recording allergies (or confirming none), proceed to medical conditions.",
@@ -282,7 +282,7 @@ flow_config: FlowConfig = {
             ],
         },
         "get_conditions": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Collect medical condition information. Ask about any medical conditions they have. After recording conditions (or confirming none), proceed to visit reasons.",
@@ -320,7 +320,7 @@ flow_config: FlowConfig = {
             ],
         },
         "get_visit_reasons": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Collect information about the reason for their visit. Ask what brings them to the doctor today. After recording their reasons, proceed to verification.",
@@ -358,7 +358,7 @@ flow_config: FlowConfig = {
             ],
         },
         "verify": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": """Review all collected information with the patient. Follow these steps:
@@ -391,7 +391,7 @@ Be thorough in reviewing all details and wait for explicit confirmation.""",
             ],
         },
         "confirm": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Once confirmed, thank them, then use the complete_intake function to end the conversation.",
@@ -410,7 +410,7 @@ Be thorough in reviewing all details and wait for explicit confirmation.""",
             ],
         },
         "end": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Thank them for their time and end the conversation.",

--- a/examples/static/restaurant_reservation.py
+++ b/examples/static/restaurant_reservation.py
@@ -93,15 +93,15 @@ async def record_time(args: FlowArgs) -> FlowResult:
 
 flow_config: FlowConfig = {
     "initial_node": "start",
-    "initial_system_message": [
-        {
-            "role": "system",
-            "content": "You are a restaurant reservation assistant for La Maison, an upscale French restaurant. You must ALWAYS use one of the available functions to progress the conversation. This is a phone conversations and your responses will be converted to audio. Avoid outputting special characters and emojis. Be causal and friendly.",
-        }
-    ],
     "nodes": {
         "start": {
-            "messages": [
+            "role_messages": [
+                {
+                    "role": "system",
+                    "content": "You are a restaurant reservation assistant for La Maison, an upscale French restaurant. You must ALWAYS use one of the available functions to progress the conversation. This is a phone conversations and your responses will be converted to audio. Avoid outputting special characters and emojis. Be causal and friendly.",
+                }
+            ],
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Warmly greet the customer and ask how many people are in their party.",
@@ -127,7 +127,7 @@ flow_config: FlowConfig = {
             ],
         },
         "get_time": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Ask what time they'd like to dine. Restaurant is open 5 PM to 10 PM. After they provide a time, confirm it's within operating hours before recording. Use 24-hour format for internal recording (e.g., 17:00 for 5 PM).",
@@ -157,7 +157,7 @@ flow_config: FlowConfig = {
             ],
         },
         "confirm": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Confirm the reservation details and end the conversation.",
@@ -176,7 +176,7 @@ flow_config: FlowConfig = {
             ],
         },
         "end": {
-            "messages": [{"role": "system", "content": "Thank them and end the conversation."}],
+            "task_messages": [{"role": "system", "content": "Thank them and end the conversation."}],
             "functions": [],
             "post_actions": [{"type": "end_conversation"}],
         },

--- a/examples/static/travel_planner.py
+++ b/examples/static/travel_planner.py
@@ -119,15 +119,15 @@ async def record_activities(args: FlowArgs) -> ActivitiesResult:
 
 flow_config: FlowConfig = {
     "initial_node": "start",
-    "initial_system_message": [
-        {
-            "role": "system",
-            "content": "You are a travel planning assistant with Summit & Sand Getaways. You must ALWAYS use one of the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Avoid outputting special characters and emojis.",
-        }
-    ],
     "nodes": {
         "start": {
-            "messages": [
+            "role_messages": [
+                {
+                    "role": "system",
+                    "content": "You are a travel planning assistant with Summit & Sand Getaways. You must ALWAYS use one of the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Avoid outputting special characters and emojis.",
+                }
+            ],
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "For this step, ask if they're interested in planning a beach vacation or a mountain retreat, and wait for them to choose. Start with an enthusiastic greeting and be conversational; you're helping them plan their dream vacation.",
@@ -155,7 +155,7 @@ flow_config: FlowConfig = {
             ],
         },
         "choose_beach": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "You are handling beach vacation planning. Use the available functions:\n - Use select_destination when the user chooses their preferred beach location\n - After destination is selected, dates will be collected automatically\n\nAvailable beach destinations are: 'Maui', 'Cancun', or 'Maldives'. After they choose, confirm their selection. Be enthusiastic and paint a picture of each destination.",
@@ -185,7 +185,7 @@ flow_config: FlowConfig = {
             ],
         },
         "choose_mountain": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "You are handling mountain retreat planning. Use the available functions:\n - Use select_destination when the user chooses their preferred mountain location\n - After destination is selected, dates will be collected automatically\n\nAvailable mountain destinations are: 'Swiss Alps', 'Rocky Mountains', or 'Himalayas'. After they choose, confirm their selection. Be enthusiastic and paint a picture of each destination.",
@@ -215,7 +215,7 @@ flow_config: FlowConfig = {
             ],
         },
         "get_dates": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Handle travel date selection. Use the available functions:\n - Use record_dates when the user specifies their travel dates (can be used multiple times if they change their mind)\n - After dates are recorded, activities will be collected automatically\n\nAsk for their preferred travel dates within the next 6 months. After recording dates, confirm the selection.",
@@ -250,7 +250,7 @@ flow_config: FlowConfig = {
             ],
         },
         "get_activities": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Handle activity preferences. Use the available functions:\n - Use record_activities to save their activity preferences\n - After activities are recorded, verification will happen automatically\n\nFor beach destinations, suggest: snorkeling, surfing, sunset cruise\nFor mountain destinations, suggest: hiking, skiing, mountain biking\n\nAfter they choose, confirm their selections.",
@@ -282,7 +282,7 @@ flow_config: FlowConfig = {
             ],
         },
         "verify_itinerary": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Review the complete itinerary with the user. Summarize their destination, dates, and chosen activities. Use revise_plan to make changes or confirm_booking if they're happy. Be thorough in reviewing all details and ask for their confirmation.",
@@ -310,7 +310,7 @@ flow_config: FlowConfig = {
             ],
         },
         "confirm_booking": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "The booking is confirmed. Share some relevant tips about their chosen destination, thank them warmly, and use end to complete the conversation.",
@@ -332,7 +332,7 @@ flow_config: FlowConfig = {
             ],
         },
         "end": {
-            "messages": [
+            "task_messages": [
                 {
                     "role": "system",
                     "content": "Wish them a wonderful trip and end the conversation.",

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -49,7 +49,7 @@ Example:
 class NodeConfigRequired(TypedDict):
     """Required fields for node configuration."""
 
-    messages: List[dict]
+    task_messages: List[dict]
     functions: List[dict]
 
 
@@ -57,47 +57,39 @@ class NodeConfig(NodeConfigRequired, total=False):
     """Configuration for a single node in the flow.
 
     Required fields:
-        messages: List of message dicts in provider-specific format
+        task_messages: List of message dicts defining the current node's objectives
         functions: List of function definitions in provider-specific format
 
     Optional fields:
+        role_messages: List of message dicts defining the bot's role/personality
         pre_actions: Actions to execute before LLM inference
         post_actions: Actions to execute after LLM inference
 
     Example:
         {
-            "messages": [
+            "role_messages": [
                 {
                     "role": "system",
-                    "content": "You are handling orders..."
+                    "content": "You are a helpful assistant..."
                 }
             ],
-            "functions": [
+            "task_messages": [
                 {
-                    "type": "function",
-                    "function": {
-                        "name": "process_order",
-                        "description": "Process the order",
-                        "parameters": {...}
-                    }
+                    "role": "system",
+                    "content": "Ask the user for their name..."
                 }
             ],
-            "pre_actions": [
-                {
-                    "type": "tts_say",
-                    "text": "Processing your order..."
-                }
-            ],
-            "post_actions": [
-                {
-                    "type": "update_db",
-                    "user_id": 123,
-                    "data": {"status": "completed"}
-                }
-            ]
+            "functions": [...],
+            "pre_actions": [...],
+            "post_actions": [...]
         }
     """
 
+    role_messages: List[Dict[str, Any]]
+    pre_actions: List[Dict[str, Any]]
+    post_actions: List[Dict[str, Any]]
+
+    role_messages: List[Dict[str, Any]]
     pre_actions: List[Dict[str, Any]]
     post_actions: List[Dict[str, Any]]
 
@@ -114,12 +106,13 @@ class FlowConfig(TypedDict):
             "initial_node": "greeting",
             "nodes": {
                 "greeting": {
-                    "messages": [...],
+                    "role_messages": [...],
+                    "task_messages": [...],
                     "functions": [...],
                     "pre_actions": [...]
                 },
                 "process_order": {
-                    "messages": [...],
+                    "task_messages": [...],
                     "functions": [...],
                     "post_actions": [...]
                 }


### PR DESCRIPTION
## Flows code

### Changed

- Nodes now have two message types to better delineate defining the role or
  persona of the bot from the task it needs to accomplish. The message types are:

  - `role_message`, which defines the personality or role of the bot
  - `task_message`, which defines the task to be completed for a given node

- `role_messages` can be defined for the initial node and then inherited by
  subsequent nodes. You can treat this as an LLM "system" message.

- Simplified FlowManager initialization by removing the need for manual context
  setup in both static and dynamic flows. Now, you need to create a `FlowManager`
  and initialize it to start the flow.
- All examples have been updated to align with the API changes.

---

## Flows editor

Also, the Flow Editor needed to be updated for the new message structure as well. This PR includes an update there, as well as updates to all editor JSON examples.