### PR TITLE
Improve LLM completion timing for edge and node functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to **Pipecat Flows** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Updated `FlowManager` to more predictably handle function calls:
+
+  - Edge functions (which transition to a new node) now result in an LLM
+    completion after both the function call and messages are added to the
+    LLM's context.
+  - Node functions (which execute a function call without transitioning nodes)
+    result in an LLM completion upon the function call result returning.
+  - This change also improves the reliability of the pre- and post-action
+    execution timing.
+  - Note: the FlowManager has a new required arg, `context_aggregator`.
+
+- Updated all examples to align with the new changes.
+
 ## [0.0.10] - 2024-12-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ Here's a basic example of setting up a static conversation flow:
 from pipecat_flows import FlowManager
 
 # Initialize flow manager with static configuration
-flow_manager = FlowManager(task, llm, tts, flow_config=flow_config)
+flow_manager = FlowManager(
+    task=task,
+    llm=llm,
+    context_aggregator=context_aggregator,
+    tts=tts,
+    flow_config=flow_config,
+)
 
 @transport.event_handler("on_first_participant_joined")
 async def on_first_participant_joined(transport, participant):
@@ -126,6 +132,11 @@ Functions come in two types:
     }
 }
 ```
+
+Functions behave differently based on their type:
+
+Node Functions execute their handler and trigger an immediate LLM completion with the result
+Edge Functions execute their handler (if any) and transition to a new node, with the LLM completion occurring after both the function result and new node's messages are added to context
 
 Functions can:
 
@@ -235,7 +246,13 @@ flow_config = {
 }
 
 # Create and initialize the FlowManager
-flow_manager = FlowManager(task, llm, tts, flow_config=flow_config)
+flow_manager = FlowManager(
+    task=task,
+    llm=llm,
+    context_aggregator=context_aggregator,
+    tts=tts,
+    flow_config=flow_config,
+)
 await flow_manager.initialize()
 ```
 
@@ -276,7 +293,13 @@ def create_initial_node() -> NodeConfig:
     }
 
 # Initialize with transition callback
-flow_manager = FlowManager(task, llm, tts, transition_callback=handle_transitions)
+flow_manager = FlowManager(
+    task=task,
+    llm=llm,
+    context_aggregator=context_aggregator,
+    tts=tts,
+    transition_callback=handle_transition,
+)
 await flow_manager.initialize()
 
 @transport.event_handler("on_first_participant_joined")

--- a/examples/dynamic/insurance_anthropic.py
+++ b/examples/dynamic/insurance_anthropic.py
@@ -429,7 +429,11 @@ async def main():
 
         # Initialize flow manager with transition callback
         flow_manager = FlowManager(
-            task=task, llm=llm, tts=tts, transition_callback=handle_insurance_transition
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            transition_callback=handle_insurance_transition,
         )
 
         @transport.event_handler("on_first_participant_joined")
@@ -439,7 +443,6 @@ async def main():
             await flow_manager.initialize()
             # Set initial node
             await flow_manager.set_node("initial", create_initial_node())
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         # Run the pipeline
         runner = PipelineRunner()

--- a/examples/dynamic/insurance_gemini.py
+++ b/examples/dynamic/insurance_gemini.py
@@ -409,7 +409,11 @@ async def main():
 
         # Initialize flow manager with transition callback
         flow_manager = FlowManager(
-            task=task, llm=llm, tts=tts, transition_callback=handle_insurance_transition
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            transition_callback=handle_insurance_transition,
         )
 
         @transport.event_handler("on_first_participant_joined")
@@ -419,7 +423,6 @@ async def main():
             await flow_manager.initialize()
             # Set initial node
             await flow_manager.set_node("initial", create_initial_node())
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         # Run the pipeline
         runner = PipelineRunner()

--- a/examples/dynamic/insurance_openai.py
+++ b/examples/dynamic/insurance_openai.py
@@ -403,7 +403,11 @@ async def main():
 
         # Initialize flow manager with transition callback
         flow_manager = FlowManager(
-            task=task, llm=llm, tts=tts, transition_callback=handle_insurance_transition
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            transition_callback=handle_insurance_transition,
         )
 
         @transport.event_handler("on_first_participant_joined")
@@ -413,8 +417,6 @@ async def main():
             await flow_manager.initialize()
             logger.debug("Setting initial node")
             await flow_manager.set_node("initial", create_initial_node())
-            logger.debug("Queueing initial context")
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         # Run the pipeline
         runner = PipelineRunner()

--- a/examples/static/movie_explorer_anthropic.py
+++ b/examples/static/movie_explorer_anthropic.py
@@ -466,13 +466,18 @@ async def main():
         task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True))
 
         # Initialize flow manager
-        flow_manager = FlowManager(task=task, llm=llm, tts=tts, flow_config=flow_config)
+        flow_manager = FlowManager(
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            flow_config=flow_config,
+        )
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             await flow_manager.initialize()
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         runner = PipelineRunner()
         await runner.run(task)

--- a/examples/static/movie_explorer_gemini.py
+++ b/examples/static/movie_explorer_gemini.py
@@ -453,13 +453,18 @@ async def main():
         task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True))
 
         # Initialize flow manager
-        flow_manager = FlowManager(task=task, llm=llm, tts=tts, flow_config=flow_config)
+        flow_manager = FlowManager(
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            flow_config=flow_config,
+        )
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             await flow_manager.initialize()
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         runner = PipelineRunner()
         await runner.run(task)

--- a/examples/static/movie_explorer_openai.py
+++ b/examples/static/movie_explorer_openai.py
@@ -470,13 +470,18 @@ async def main():
         task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True))
 
         # Initialize flow manager
-        flow_manager = FlowManager(task=task, llm=llm, tts=tts, flow_config=flow_config)
+        flow_manager = FlowManager(
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            flow_config=flow_config,
+        )
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             await flow_manager.initialize()
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         runner = PipelineRunner()
         await runner.run(task)

--- a/examples/static/patient_intake.py
+++ b/examples/static/patient_intake.py
@@ -465,15 +465,19 @@ async def main():
         task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True))
 
         # Initialize flow manager with LLM
-        flow_manager = FlowManager(task=task, llm=llm, tts=tts, flow_config=flow_config)
+        flow_manager = FlowManager(
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            flow_config=flow_config,
+        )
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             # Initialize the flow processor
             await flow_manager.initialize()
-            # Kick off the conversation using the context aggregator
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         runner = PipelineRunner()
         await runner.run(task)

--- a/examples/static/restaurant_reservation.py
+++ b/examples/static/restaurant_reservation.py
@@ -225,15 +225,19 @@ async def main():
         task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True))
 
         # Initialize flow manager with LLM
-        flow_manager = FlowManager(task=task, llm=llm, tts=tts, flow_config=flow_config)
+        flow_manager = FlowManager(
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            flow_config=flow_config,
+        )
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             # Initialize the flow processor
             await flow_manager.initialize()
-            # Kick off the conversation using the context aggregator
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         runner = PipelineRunner()
         await runner.run(task)

--- a/examples/static/travel_planner.py
+++ b/examples/static/travel_planner.py
@@ -388,15 +388,19 @@ async def main():
         task = PipelineTask(pipeline, PipelineParams(allow_interruptions=True))
 
         # Initialize flow manager with LLM
-        flow_manager = FlowManager(task=task, llm=llm, tts=tts, flow_config=flow_config)
+        flow_manager = FlowManager(
+            task=task,
+            llm=llm,
+            context_aggregator=context_aggregator,
+            tts=tts,
+            flow_config=flow_config,
+        )
 
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(transport, participant):
             await transport.capture_participant_transcription(participant["id"])
             # Initialize the flow processor
             await flow_manager.initialize()
-            # Kick off the conversation using the context aggregator
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         runner = PipelineRunner()
         await runner.run(task)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio",
 ]
 dependencies = [
-    "pipecat-ai>=0.0.50",
+    "pipecat-ai>=0.0.53",
     "loguru~=0.7.2",
 ]
 


### PR DESCRIPTION
Issue: https://github.com/pipecat-ai/pipecat-flows/issues/67.

This fix comes in two parts:
- Pipecat: https://github.com/pipecat-ai/pipecat/pull/970
- This Flows change

This PR resolves a timing/race condition issue that resulted in variable and unpredictable timing for how LLM completions occur. This change makes both node and edge function calls predictable in that:
- Edge function calls (which transition to a new node) result in an LLM completion after both the function call result and the next nodes messages are added to the context. This ensures that the LLM responds only once and with the necessary task and context.
- Node function calls (which happen within the existing node) result in an LLM completion once the function call result is added to the context (default Pipecat behavior).

⚠️ This change is breaking in that you need to pass the context_aggregator to the FlowManager at initialization. The benefit for this is warranted though as it results in LLM completions creating a natural and controllable conversation.

For reviewing, the code change is only in the manager.py. All of the other files are changes to align with the FlowManager updates.