### PR TITLE
Update dynamic flows to specify transition_callback within the function definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,34 +27,39 @@ Example of the new pattern:
 
 ### Changed
 
-- Updated dynamic flows to use per-function transition handlers:
-  - Removed global `transition_callback` in favor of `transition_callbacks`
-    dict
-  - Each edge function now explicitly registers its transition handler
-  - Clearer distinction between node functions (LLM completion) and edge
-    functions (transitions)
-  - Better type safety and error detection for transition handlers
-  - Breaking change: Dynamic flows must now use `transition_callbacks` instead
-    of `transition_callback`
+- Updated dynamic flows to use per-function, inline transition callbacks:
+  - Removed global `transition_callback` from FlowManager initialization
+  - Transition handlers are now specified directly in function definitions
+  - Dynamic transitions are now specified similarly to the static flows'
+    `transition_to` field
+  - Breaking change: Dynamic flows must now specify transition callbacks in
+    function configuration
 
 Example of the new pattern:
 
 ```python
-# Before - global router
+# Before - global transition callback
 flow_manager = FlowManager(
     transition_callback=handle_transition
 )
 
-# After - per-function transitions
-flow_manager = FlowManager(
-    transition_callbacks={
-        "collect_age": handle_age_collection,
-        "collect_status": handle_status_collection
+# After - inline transition callbacks
+def create_node() -> NodeConfig:
+    return {
+        "functions": [{
+            "type": "function",
+            "function": {
+                "name": "collect_age",
+                "handler": collect_age,
+                "description": "Record user's age",
+                "parameters": {...},
+                "transition_callback": handle_age_collection
+            }
+        }]
     }
-)
 ```
 
-- Updated all dynamic flow examples to use the new transition handler pattern
+- Updated dynamic flow examples to use the new `transition_callback` pattern.
 
 ## [0.0.11] - 2025-01-19
 

--- a/examples/dynamic/insurance_anthropic.py
+++ b/examples/dynamic/insurance_anthropic.py
@@ -148,6 +148,32 @@ async def end_quote() -> FlowResult:
     return {"status": "completed"}
 
 
+# Transition callbacks and handlers
+async def handle_age_collection(args: Dict, flow_manager: FlowManager):
+    flow_manager.state["age"] = args["age"]
+    await flow_manager.set_node("marital_status", create_marital_status_node())
+
+
+async def handle_marital_status_collection(args: Dict, flow_manager: FlowManager):
+    flow_manager.state["marital_status"] = args["marital_status"]
+    await flow_manager.set_node(
+        "quote_calculation",
+        create_quote_calculation_node(
+            flow_manager.state["age"], flow_manager.state["marital_status"]
+        ),
+    )
+
+
+async def handle_quote_calculation(args: Dict, flow_manager: FlowManager):
+    quote = await calculate_quote(args)
+    flow_manager.state["quote"] = quote
+    await flow_manager.set_node("quote_results", create_quote_results_node(quote))
+
+
+async def handle_end_quote(_: Dict, flow_manager: FlowManager):
+    await flow_manager.set_node("end", create_end_node())
+
+
 # Node configurations
 def create_initial_node() -> NodeConfig:
     """Create the initial node asking for age."""
@@ -192,6 +218,7 @@ def create_initial_node() -> NodeConfig:
                     "properties": {"age": {"type": "integer"}},
                     "required": ["age"],
                 },
+                "transition_callback": handle_age_collection,
             }
         ],
     }
@@ -223,6 +250,7 @@ def create_marital_status_node() -> NodeConfig:
                     },
                     "required": ["marital_status"],
                 },
+                "transition_callback": handle_marital_status_collection,
             }
         ],
     }
@@ -259,6 +287,7 @@ def create_quote_calculation_node(age: int, marital_status: str) -> NodeConfig:
                     },
                     "required": ["age", "marital_status"],
                 },
+                "transition_callback": handle_quote_calculation,
             }
         ],
     }
@@ -309,6 +338,7 @@ def create_quote_results_node(
                 "handler": end_quote,
                 "description": "Complete the quote process",
                 "input_schema": {"type": "object", "properties": {}},
+                "transition_callback": handle_end_quote,
             },
         ],
     }
@@ -341,32 +371,6 @@ def create_end_node() -> NodeConfig:
         ],
         "post_actions": [{"type": "end_conversation"}],
     }
-
-
-# Transition callbacks and handlers
-async def handle_age_collection(args: Dict, flow_manager: FlowManager):
-    flow_manager.state["age"] = args["age"]
-    await flow_manager.set_node("marital_status", create_marital_status_node())
-
-
-async def handle_marital_status_collection(args: Dict, flow_manager: FlowManager):
-    flow_manager.state["marital_status"] = args["marital_status"]
-    await flow_manager.set_node(
-        "quote_calculation",
-        create_quote_calculation_node(
-            flow_manager.state["age"], flow_manager.state["marital_status"]
-        ),
-    )
-
-
-async def handle_quote_calculation(args: Dict, flow_manager: FlowManager):
-    quote = await calculate_quote(args)
-    flow_manager.state["quote"] = quote
-    await flow_manager.set_node("quote_results", create_quote_results_node(quote))
-
-
-async def handle_end_quote(_: Dict, flow_manager: FlowManager):
-    await flow_manager.set_node("end", create_end_node())
 
 
 async def main():
@@ -417,12 +421,6 @@ async def main():
             llm=llm,
             context_aggregator=context_aggregator,
             tts=tts,
-            transition_callbacks={
-                "collect_age": handle_age_collection,
-                "collect_marital_status": handle_marital_status_collection,
-                "calculate_quote": handle_quote_calculation,
-                "end_quote": handle_end_quote,
-            },
         )
 
         @transport.event_handler("on_first_participant_joined")

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -67,7 +67,6 @@ class FlowManager:
         initialized: Whether the manager has been initialized
         nodes: Node configurations for static flows
         current_functions: Currently registered function names
-        transition_callbacks: Map of function names to their transition handlers
     """
 
     def __init__(
@@ -78,7 +77,6 @@ class FlowManager:
         context_aggregator: Any,
         tts: Optional[Any] = None,
         flow_config: Optional[FlowConfig] = None,
-        transition_callbacks: Optional[Dict[str, TransitionHandler]] = None,
     ):
         """Initialize the flow manager.
 
@@ -89,9 +87,6 @@ class FlowManager:
             tts: Optional TTS service for voice actions
             flow_config: Optional static flow configuration. If provided,
                 operates in static mode with predefined nodes
-            transition_callbacks: Map of function names to their transition handlers
-                for dynamic flows. Each handler should be an async function that
-                takes (args, flow_manager) parameters
 
         Raises:
             ValueError: If any transition handler is not a valid async callable
@@ -103,10 +98,6 @@ class FlowManager:
         self.adapter = create_adapter(llm)
         self.initialized = False
         self._context_aggregator = context_aggregator
-        self.transition_callbacks = transition_callbacks or {}
-
-        # Validate handlers at initialization
-        self._validate_transition_handlers()
 
         # Set up static or dynamic mode
         if flow_config:
@@ -122,19 +113,20 @@ class FlowManager:
         self.current_functions: Set[str] = set()  # Track registered functions
         self.current_node: Optional[str] = None
 
-    def _validate_transition_handlers(self) -> None:
-        """Validate all transition handlers at initialization.
+    def _validate_transition_callback(self, name: str, callback: Any) -> None:
+        """Validate a transition callback.
 
-        Ensures all registered handlers are async callables with the correct signature.
+        Args:
+            name: Name of the function the callback is for
+            callback: The callback to validate
 
         Raises:
-            ValueError: If any handler is not callable or not async
+            ValueError: If callback is not a valid async callable
         """
-        for name, handler in self.transition_callbacks.items():
-            if not callable(handler):
-                raise ValueError(f"Handler for {name} must be callable")
-            if not inspect.iscoroutinefunction(handler):
-                raise ValueError(f"Handler for {name} must be async")
+        if not callable(callback):
+            raise ValueError(f"Transition callback for {name} must be callable")
+        if not inspect.iscoroutinefunction(callback):
+            raise ValueError(f"Transition callback for {name} must be async")
 
     async def initialize(self) -> None:
         """Initialize the flow manager."""
@@ -235,28 +227,36 @@ class FlowManager:
             logger.warning(f"Static transition failed: Node '{function_name}' not found")
 
     async def _create_transition_func(
-        self, name: str, handler: Optional[Callable], transition_to: Optional[str]
+        self,
+        name: str,
+        handler: Optional[Callable],
+        transition_to: Optional[str],
+        transition_callback: Optional[Callable] = None,
     ) -> Callable:
         """Create a transition function for the given name and handler.
-
-        Creates a function that will be called when the LLM invokes a tool.
-        Handles both node functions and edge functions:
-        - Node functions: Execute handler and allow LLM completion
-        - Edge functions: Execute handler and transition without LLM completion
-
-        A function is considered an edge function if it either:
-        - Has a transition_to parameter (static flows)
-        - Has a registered transition handler (dynamic flows)
 
         Args:
             name: Name of the function being registered
             handler: Optional function to process data
             transition_to: Optional node to transition to (static flows)
+            transition_callback: Optional callback for dynamic transitions
 
         Returns:
             Callable: Async function that handles the tool invocation
+
+        Raises:
+            ValueError: If both transition_to and transition_callback are specified
         """
-        is_edge_function = bool(transition_to) or name in self.transition_callbacks
+        if transition_to and transition_callback:
+            raise ValueError(
+                f"Function {name} cannot have both transition_to and transition_callback"
+            )
+
+        # Validate transition callback if provided
+        if transition_callback:
+            self._validate_transition_callback(name, transition_callback)
+
+        is_edge_function = bool(transition_to) or bool(transition_callback)
 
         async def transition_func(
             function_name: str,
@@ -282,9 +282,9 @@ class FlowManager:
                         if transition_to:  # Static flow
                             logger.debug(f"Static transition to: {transition_to}")
                             await self.set_node(transition_to, self.nodes[transition_to])
-                        elif name in self.transition_callbacks:  # Dynamic flow
+                        elif transition_callback:  # Dynamic flow
                             logger.debug(f"Dynamic transition for: {name}")
-                            await self.transition_callbacks[name](args, self)
+                            await transition_callback(args, self)
 
                     properties = FunctionCallResultProperties(
                         run_llm=False, on_context_updated=on_context_updated
@@ -331,9 +331,10 @@ class FlowManager:
     async def _register_function(
         self,
         name: str,
-        handler: Optional[Callable],
-        transition_to: Optional[str],
         new_functions: Set[str],
+        handler: Optional[Callable],
+        transition_to: Optional[str] = None,
+        transition_callback: Optional[Callable] = None,
     ) -> None:
         """Register a function with the LLM if not already registered.
 
@@ -342,6 +343,7 @@ class FlowManager:
             handler: Either a callable function or a string. If string starts with
                     '__function__:', extracts the function name after the prefix
             transition_to: Optional node name to transition to after function execution
+            transition_callback: Optional callback for dynamic transitions
             new_functions: Set to track newly registered functions for this node
 
         Raises:
@@ -355,7 +357,10 @@ class FlowManager:
                     handler = self._lookup_function(func_name)
 
                 self.llm.register_function(
-                    name, await self._create_transition_func(name, handler, transition_to)
+                    name,
+                    await self._create_transition_func(
+                        name, handler, transition_to, transition_callback
+                    ),
                 )
                 new_functions.add(name)
                 logger.debug(f"Registered function: {name}")
@@ -379,15 +384,33 @@ class FlowManager:
                     del decl["handler"]
 
     def _remove_transition_info(self, tool_config: Dict[str, Any]) -> None:
-        """Remove transition information from tool configuration."""
-        if "function" in tool_config and "transition_to" in tool_config["function"]:
-            del tool_config["function"]["transition_to"]
-        elif "transition_to" in tool_config:
-            del tool_config["transition_to"]
+        """Remove transition information from tool configuration.
+
+        Removes transition_to and transition_callback fields to prevent them from being
+        sent to the LLM provider.
+
+        Args:
+            tool_config: Function configuration to clean
+        """
+        if "function" in tool_config:
+            # Clean OpenAI format
+            if "transition_to" in tool_config["function"]:
+                del tool_config["function"]["transition_to"]
+            if "transition_callback" in tool_config["function"]:
+                del tool_config["function"]["transition_callback"]
         elif "function_declarations" in tool_config:
+            # Clean Gemini format
             for decl in tool_config["function_declarations"]:
                 if "transition_to" in decl:
                     del decl["transition_to"]
+                if "transition_callback" in decl:
+                    del decl["transition_callback"]
+        else:
+            # Clean Anthropic format
+            if "transition_to" in tool_config:
+                del tool_config["transition_to"]
+            if "transition_callback" in tool_config:
+                del tool_config["transition_callback"]
 
     async def set_node(self, node_id: str, node_config: NodeConfig) -> None:
         """Set up a new conversation node and transition to it.
@@ -445,8 +468,15 @@ class FlowManager:
                         name = declaration["name"]
                         handler = declaration.get("handler")
                         transition_to = declaration.get("transition_to")
+                        transition_callback = declaration.get("transition_callback")
                         logger.debug(f"Processing function: {name}")
-                        await self._register_function(name, handler, transition_to, new_functions)
+                        await self._register_function(
+                            name=name,
+                            new_functions=new_functions,
+                            handler=handler,
+                            transition_to=transition_to,
+                            transition_callback=transition_callback,
+                        )
                 else:
                     name = self.adapter.get_function_name(func_config)
                     logger.debug(f"Processing function: {name}")
@@ -455,13 +485,21 @@ class FlowManager:
                     if "function" in func_config:
                         handler = func_config["function"].get("handler")
                         transition_to = func_config["function"].get("transition_to")
+                        transition_callback = func_config["function"].get("transition_callback")
                     else:
                         handler = func_config.get("handler")
                         transition_to = func_config.get("transition_to")
+                        transition_callback = func_config.get("transition_callback")
 
-                    await self._register_function(name, handler, transition_to, new_functions)
+                    await self._register_function(
+                        name=name,
+                        new_functions=new_functions,
+                        handler=handler,
+                        transition_to=transition_to,
+                        transition_callback=transition_callback,
+                    )
 
-                # Create tool config (after removing handler and transition_to)
+                # Create tool config (after removing handler and transition info)
                 tool_config = copy.deepcopy(func_config)
                 self._remove_handlers(tool_config)
                 self._remove_transition_info(tool_config)


### PR DESCRIPTION
In switching to a per function handler, we have the opportunity to mimic the static flow format of including the transition callback within the node itself. This change does exactly that; `transition_callback` is now defined within the function itself, matching the implementation for static flows.