### PR TITLE
Fix an issue where multiple, consecutive function calls result in repeat completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ def create_node() -> NodeConfig:
 
 - Updated dynamic flow examples to use the new `transition_callback` pattern.
 
+### Fixed
+
+- Fixed an issue where multiple, consecutive function calls could result in two completions.
+
 ## [0.0.11] - 2025-01-19
 
 ### Changed

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -300,9 +300,6 @@ class FlowManager:
                                 elif transition_callback:  # Dynamic flow
                                     logger.debug(f"Dynamic transition for: {name}")
                                     await transition_callback(args, self)
-                                # Reset counter after transition completes
-                                self._pending_function_calls = 0
-                                logger.debug("Reset pending function calls counter")
                             else:
                                 logger.debug(
                                     f"Skipping transition, {self._pending_function_calls} calls still pending"

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -259,6 +259,47 @@ class FlowManager:
 
         is_edge_function = bool(transition_to) or bool(transition_callback)
 
+        def decrease_pending_function_calls() -> None:
+            """Decrease the pending function calls counter if greater than zero."""
+            if self._pending_function_calls > 0:
+                self._pending_function_calls -= 1
+                logger.debug(
+                    f"Function call completed: {name} (remaining: {self._pending_function_calls})"
+                )
+
+        async def on_context_updated_edge(args: Dict[str, Any], result_callback: Callable) -> None:
+            """Handle context updates for edge functions with transitions."""
+            try:
+                decrease_pending_function_calls()
+
+                # Only process transition if this was the last pending call
+                if self._pending_function_calls == 0:
+                    if transition_to:  # Static flow
+                        logger.debug(f"Static transition to: {transition_to}")
+                        await self.set_node(transition_to, self.nodes[transition_to])
+                    elif transition_callback:  # Dynamic flow
+                        logger.debug(f"Dynamic transition for: {name}")
+                        await transition_callback(args, self)
+                    # Reset counter after transition completes
+                    self._pending_function_calls = 0
+                    logger.debug("Reset pending function calls counter")
+                else:
+                    logger.debug(
+                        f"Skipping transition, {self._pending_function_calls} calls still pending"
+                    )
+            except Exception as e:
+                logger.error(f"Error in transition: {str(e)}")
+                self._pending_function_calls = 0
+                await result_callback(
+                    {"status": "error", "error": str(e)},
+                    properties=None,  # Clear properties to prevent further callbacks
+                )
+                raise  # Re-raise to prevent further processing
+
+        async def on_context_updated_node() -> None:
+            """Handle context updates for node functions without transitions."""
+            decrease_pending_function_calls()
+
         async def transition_func(
             function_name: str,
             tool_call_id: str,
@@ -283,46 +324,19 @@ class FlowManager:
                     result = {"status": "acknowledged"}
                     logger.debug(f"Function called without handler: {name}")
 
-                if is_edge_function:
+                # For edge functions, prevent LLM completion until transition (run_llm=False)
+                # For node functions, allow immediate completion (run_llm=True)
+                async def on_context_updated() -> None:
+                    if is_edge_function:
+                        await on_context_updated_edge(args, result_callback)
+                    else:
+                        await on_context_updated_node()
 
-                    async def on_context_updated() -> None:
-                        try:
-                            self._pending_function_calls -= 1
-                            logger.debug(
-                                f"Function call completed: {name} (remaining: {self._pending_function_calls})"
-                            )
-
-                            # Only process transition if this was the last pending call
-                            if self._pending_function_calls == 0:
-                                if transition_to:  # Static flow
-                                    logger.debug(f"Static transition to: {transition_to}")
-                                    await self.set_node(transition_to, self.nodes[transition_to])
-                                elif transition_callback:  # Dynamic flow
-                                    logger.debug(f"Dynamic transition for: {name}")
-                                    await transition_callback(args, self)
-                            else:
-                                logger.debug(
-                                    f"Skipping transition, {self._pending_function_calls} calls still pending"
-                                )
-                        except Exception as e:
-                            logger.error(f"Error in transition: {str(e)}")
-                            self._pending_function_calls = 0
-                            await result_callback(
-                                {"status": "error", "error": str(e)},
-                                properties=None,  # Clear properties to prevent further callbacks
-                            )
-                            raise  # Re-raise to prevent further processing
-
-                    properties = FunctionCallResultProperties(
-                        run_llm=False, on_context_updated=on_context_updated
-                    )
-                    await result_callback(result, properties=properties)
-                else:
-                    self._pending_function_calls -= 1
-                    logger.debug(
-                        f"Node function completed: {name} (remaining: {self._pending_function_calls})"
-                    )
-                    await result_callback(result)
+                properties = FunctionCallResultProperties(
+                    run_llm=not is_edge_function,
+                    on_context_updated=on_context_updated,
+                )
+                await result_callback(result, properties=properties)
 
             except Exception as e:
                 logger.error(f"Error in transition function {name}: {str(e)}")

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -846,7 +846,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             # Get the registered function and test it
             name, func = self.mock_llm.register_function.call_args[0]
 
-            async def callback(result):
+            async def callback(result, properties=None):
                 self.assertEqual(result["status"], "success")
                 self.assertEqual(result["args"], {"test": "value"})
 


### PR DESCRIPTION
This was a tricky one. In 0.0.11, I added constraint that completions would happen after either:
- Node function: just a function call
- Edge function: a function call and an update to the context

What I didn't account for is the case where the LLM will call a function multiple times consecutively. You can see this in the `food_ordering.py` example if you ask it for multiple orders. The LLM will execute the function call once per item asked. This results in calling the function multiple times.

For example, ordering "a large cheese and a medium pepperoni" triggers:
```python
2025-01-28 18:28:01.783 | INFO     | pipecat.processors.aggregators.openai_llm_context:call_function:200 - Calling function select_pizza_order with arguments {'size': 'medium', 'type': 'pepperoni'}
2025-01-28 18:28:01.784 | INFO     | pipecat.processors.aggregators.openai_llm_context:call_function:200 - Calling function select_pizza_order with arguments {'size': 'large', 'type': 'cheese'}
```

As a solution, I'm counting pending function calls. And, I'm waiting to transition to the next node until those function calls have yielded results. This is done through a counter. I went in this direction to not have to debounce or add latency.