### PR TITLE
Bump version for 0.0.13 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
           source .venv/bin/activate
           python -m pip install --upgrade pip
           pip install -r dev-requirements.txt -r test-requirements.txt
+          pip uninstall -y google-generativeai google-genai google-ai-generativelanguage
+          pip install "google-genai==0.7.0"
           pip install "pipecat-ai[google,openai,anthropic]"
           pip install -e .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to **Pipecat Flows** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.13] - 2025-02-06
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pipecat-ai-flows"
-version = "0.0.12"
+version = "0.0.13"
 description = "Conversation Flow management for Pipecat AI applications"
 license = { text = "BSD 2-Clause License" }
 readme = "README.md"
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio",
 ]
 dependencies = [
-    "pipecat-ai>=0.0.53",
+    "pipecat-ai>=0.0.55",
     "loguru~=0.7.2",
 ]
 


### PR DESCRIPTION
I'm also bumping the minimum pipecat-ai version since it requires a Gemini fix in 0.0.55.