### PR TITLE
Revert "tts_say action should use TTSSpeakFrame"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **Pipecat Flows** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.14] - 2025-02-08
+
+### Reverted
+
+- Temporarily reverted the deprecation of the `tts` parameter in
+  `FlowManager.__init__()`. This feature will be deprecated in a future release
+  after the required Pipecat changes are completed.
+
 ## [0.0.13] - 2025-02-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ flow_manager = FlowManager(
     task=task,
     llm=llm,
     context_aggregator=context_aggregator,
+    tts=tts,
     flow_config=flow_config,
 )
 
@@ -287,6 +288,7 @@ flow_manager = FlowManager(
     task=task,
     llm=llm,
     context_aggregator=context_aggregator,
+    tts=tts,
     flow_config=flow_config,
 )
 await flow_manager.initialize()
@@ -349,6 +351,7 @@ flow_manager = FlowManager(
     task=task,
     llm=llm,
     context_aggregator=context_aggregator,
+    tts=tts,
 )
 await flow_manager.initialize()
 

--- a/examples/dynamic/insurance_anthropic.py
+++ b/examples/dynamic/insurance_anthropic.py
@@ -422,6 +422,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
         )
 
         @transport.event_handler("on_first_participant_joined")

--- a/examples/dynamic/insurance_gemini.py
+++ b/examples/dynamic/insurance_gemini.py
@@ -404,6 +404,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
         )
 
         @transport.event_handler("on_first_participant_joined")

--- a/examples/dynamic/insurance_openai.py
+++ b/examples/dynamic/insurance_openai.py
@@ -394,9 +394,7 @@ async def main():
 
         # Initialize flow manager with transition callback
         flow_manager = FlowManager(
-            task=task,
-            llm=llm,
-            context_aggregator=context_aggregator,
+            task=task, llm=llm, context_aggregator=context_aggregator, tts=tts
         )
 
         @transport.event_handler("on_first_participant_joined")

--- a/examples/static/food_ordering.py
+++ b/examples/static/food_ordering.py
@@ -335,6 +335,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/examples/static/movie_explorer_anthropic.py
+++ b/examples/static/movie_explorer_anthropic.py
@@ -475,6 +475,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/examples/static/movie_explorer_gemini.py
+++ b/examples/static/movie_explorer_gemini.py
@@ -462,6 +462,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/examples/static/movie_explorer_openai.py
+++ b/examples/static/movie_explorer_openai.py
@@ -475,6 +475,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/examples/static/patient_intake_anthropic.py
+++ b/examples/static/patient_intake_anthropic.py
@@ -470,6 +470,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/examples/static/patient_intake_gemini.py
+++ b/examples/static/patient_intake_gemini.py
@@ -491,6 +491,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/examples/static/patient_intake_openai.py
+++ b/examples/static/patient_intake_openai.py
@@ -487,6 +487,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/examples/static/travel_planner.py
+++ b/examples/static/travel_planner.py
@@ -392,6 +392,7 @@ async def main():
             task=task,
             llm=llm,
             context_aggregator=context_aggregator,
+            tts=tts,
             flow_config=flow_config,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pipecat-ai-flows"
-version = "0.0.13"
+version = "0.0.14"
 description = "Conversation Flow management for Pipecat AI applications"
 license = { text = "BSD 2-Clause License" }
 readme = "README.md"

--- a/src/pipecat_flows/actions.py
+++ b/src/pipecat_flows/actions.py
@@ -22,7 +22,7 @@ Actions are used to perform side effects during conversations, such as:
 """
 
 import asyncio
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from loguru import logger
 from pipecat.frames.frames import (
@@ -45,20 +45,22 @@ class ActionManager:
     - Custom user-defined actions
 
     Built-in actions:
-    - tts_say: Speak text using TTSSpeakFrame
+    - tts_say: Speak text using TTS
     - end_conversation: End the current conversation
 
     Custom actions can be registered using register_action().
     """
 
-    def __init__(self, task: PipelineTask):
+    def __init__(self, task: PipelineTask, tts=None):
         """Initialize the action manager.
 
         Args:
             task: PipelineTask instance used to queue frames
+            tts: Optional TTS service for voice actions
         """
         self.action_handlers: Dict[str, Callable] = {}
         self.task = task
+        self.tts = tts
 
         # Register built-in actions
         self._register_action("tts_say", self._handle_tts_action)
@@ -118,13 +120,19 @@ class ActionManager:
         Args:
             action: Action configuration containing 'text' to speak
         """
+        if not self.tts:
+            logger.warning("TTS action called but no TTS service provided")
+            return
+
         text = action.get("text")
         if not text:
             logger.error("TTS action missing 'text' field")
             return
 
         try:
-            await self.task.queue_frame(TTSSpeakFrame(text=action["text"]))
+            await self.tts.say(text)
+            # TODO: Update to TTSSpeakFrame once Pipecat is fixed
+            # await self.task.queue_frame(TTSSpeakFrame(text=action["text"]))
         except Exception as e:
             logger.error(f"TTS error: {e}")
 

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -27,7 +27,6 @@ import asyncio
 import copy
 import inspect
 import sys
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union, cast
 
 from loguru import logger
@@ -71,6 +70,7 @@ class FlowManager:
     Attributes:
         task: Pipeline task for frame queueing
         llm: LLM service instance (OpenAI, Anthropic, or Google)
+        tts: Optional TTS service for voice actions
         state: Shared state dictionary across nodes
         current_node: Currently active node identifier
         initialized: Whether the manager has been initialized
@@ -94,26 +94,18 @@ class FlowManager:
             task: PipelineTask instance for queueing frames
             llm: LLM service instance (e.g., OpenAI, Anthropic)
             context_aggregator: Context aggregator for updating user context
-            tts: Optional TTS service for voice actions (deprecated)
+            tts: Optional TTS service for voice actions
             flow_config: Optional static flow configuration. If provided,
                 operates in static mode with predefined nodes
             context_strategy: Optional context strategy configuration
 
         Raises:
             ValueError: If any transition handler is not a valid async callable
-        Deprecated:
-            0.0.13: The `tts` parameter is deprecated and will be removed in a future version.
         """
-        if tts is not None:
-            warnings.warn(
-                "The 'tts' parameter is deprecated and will be removed in a future version.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         self.task = task
         self.llm = llm
-        self.action_manager = ActionManager(task)
+        self.tts = tts
+        self.action_manager = ActionManager(task, tts)
         self.adapter = create_adapter(llm)
         self.initialized = False
         self._context_aggregator = context_aggregator

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -15,17 +15,17 @@ flow management across different LLM providers. Tests cover:
 - Error cases
 
 The tests use unittest.IsolatedAsyncioTestCase for async support and
-include mocked dependencies for PipelineTask and LLM services.
+include mocked dependencies for PipelineTask, LLM services, and TTS.
 """
 
 import unittest
 from typing import Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from pipecat.frames.frames import LLMMessagesAppendFrame, LLMMessagesUpdateFrame, TTSSpeakFrame
+from pipecat.frames.frames import LLMMessagesAppendFrame, LLMMessagesUpdateFrame
 from pipecat.services.openai import OpenAILLMService
 
-from pipecat_flows.exceptions import FlowError, FlowTransitionError
+from pipecat_flows.exceptions import FlowError, FlowInitializationError, FlowTransitionError
 from pipecat_flows.manager import FlowConfig, FlowManager, NodeConfig
 from pipecat_flows.types import FlowArgs, FlowResult
 
@@ -46,6 +46,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         """Set up test fixtures before each test."""
         self.mock_task = AsyncMock()
         self.mock_llm = MagicMock(spec=OpenAILLMService)
+        self.mock_tts = AsyncMock()
 
         # Create mock context aggregator
         self.mock_context_aggregator = MagicMock()
@@ -89,6 +90,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             task=self.mock_task,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
+            tts=self.mock_tts,
             flow_config=FlowConfig(**self.static_flow_config),
         )
 
@@ -107,6 +109,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             task=self.mock_task,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
+            tts=self.mock_tts,
         )
 
         # Create test node with transition callback
@@ -140,6 +143,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             task=self.mock_task,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
+            tts=self.mock_tts,
             flow_config=FlowConfig(**self.static_flow_config),
         )
 
@@ -173,6 +177,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             task=self.mock_task,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
+            tts=self.mock_tts,
         )
         await flow_manager.initialize()
 
@@ -318,6 +323,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             task=self.mock_task,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
+            tts=self.mock_tts,
         )
         await flow_manager.initialize()
 
@@ -331,21 +337,15 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         }
 
         # Reset mock to clear initialization calls
-        self.mock_task.queue_frame.reset_mock()
+        self.mock_tts.say.reset_mock()
 
         # Set node with actions
         await flow_manager.set_node("test", node_with_actions)
 
-        # Verify TTSSpeakFrames were queued for both actions
-        tts_frames = [
-            call[0][0]
-            for call in self.mock_task.queue_frame.call_args_list
-            if isinstance(call[0][0], TTSSpeakFrame)
-        ]
-
-        self.assertEqual(len(tts_frames), 2)
-        self.assertEqual(tts_frames[0].text, "Pre action")
-        self.assertEqual(tts_frames[1].text, "Post action")
+        # Verify TTS was called for both actions
+        self.assertEqual(self.mock_tts.say.call_count, 2)
+        self.mock_tts.say.assert_any_call("Pre action")
+        self.mock_tts.say.assert_any_call("Post action")
 
     async def test_error_handling(self):
         """Test error handling in flow manager.
@@ -568,6 +568,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             task=self.mock_task,
             llm=self.mock_llm,
             context_aggregator=self.mock_context_aggregator,
+            tts=self.mock_tts,
         )
         await flow_manager.initialize()
 


### PR DESCRIPTION
- Reverting https://github.com/pipecat-ai/pipecat-flows/pull/90/commits/45ab5bfda7097c3999db21abb756f0fefde81e88
- Bumping to 0.0.14 to release this hotfix

I was mistaken. Before this change is made, we need to fix an ordering issue in the core Pipecat code to correctly handle the timing of `TTSSpeakFrame`s vs function calling. It seems the `TTSSpeakFrame` timing is too variable to rely on. We still need the unqueued `tts.say()` action.