### PR TITLE
Fix the logic for creating LLM adapters.

### DIFF
--- a/src/pipecat_flows/adapters.py
+++ b/src/pipecat_flows/adapters.py
@@ -540,8 +540,8 @@ class GeminiAdapter(LLMAdapter):
 def create_adapter(llm) -> LLMAdapter:
     """Create appropriate adapter based on LLM service type.
 
-    Uses lazy imports to avoid requiring all provider dependencies at runtime.
-    Only the dependency for the chosen provider needs to be installed.
+    Use "stringy" checks to check the LLM service type instead of trying to import each provider 
+    dependency, as those will produce scary errors on the console even when they're not needed.
 
     Args:
         llm: LLM service instance
@@ -552,35 +552,14 @@ def create_adapter(llm) -> LLMAdapter:
     Raises:
         ValueError: If LLM type is not supported or required dependency not installed
     """
-    # Try OpenAI
-    try:
-        from pipecat.services.openai import OpenAILLMService
+    if type(llm).__name__ == "OpenAILLMService":
+        return OpenAIAdapter()
 
-        if isinstance(llm, OpenAILLMService):
-            logger.debug("Creating OpenAI adapter")
-            return OpenAIAdapter()
-    except ImportError as e:
-        logger.debug(f"OpenAI import failed: {e}")
-
-    # Try Anthropic
-    try:
-        from pipecat.services.anthropic import AnthropicLLMService
-
-        if isinstance(llm, AnthropicLLMService):
-            logger.debug("Creating Anthropic adapter")
-            return AnthropicAdapter()
-    except ImportError as e:
-        logger.debug(f"Anthropic import failed: {e}")
-
-    # Try Google
-    try:
-        from pipecat.services.google import GoogleLLMService
-
-        if isinstance(llm, GoogleLLMService):
-            logger.debug("Creating Google adapter")
-            return GeminiAdapter()
-    except ImportError as e:
-        logger.debug(f"Google import failed: {e}")
+    if type(llm).__name__ == "AnthropicLLMService":
+        return AnthropicAdapter()
+    
+    if type(llm).__name__ == "GoogleLLMService":
+        return GeminiAdapter()
 
     # If we get here, either the LLM type is not supported or the required dependency is not installed
     llm_type = type(llm).__name__

--- a/src/pipecat_flows/adapters.py
+++ b/src/pipecat_flows/adapters.py
@@ -540,8 +540,7 @@ class GeminiAdapter(LLMAdapter):
 def create_adapter(llm) -> LLMAdapter:
     """Create appropriate adapter based on LLM service type.
 
-    Use "stringy" checks to check the LLM service type instead of trying to import each provider 
-    dependency, as those will produce scary errors on the console even when they're not needed.
+    Uses string-based type checking to avoid importing unnecessary dependencies.
 
     Args:
         llm: LLM service instance
@@ -552,13 +551,18 @@ def create_adapter(llm) -> LLMAdapter:
     Raises:
         ValueError: If LLM type is not supported or required dependency not installed
     """
-    if type(llm).__name__ == "OpenAILLMService":
+    llm_type = type(llm).__name__
+
+    if llm_type == "OpenAILLMService":
+        logger.debug("Creating OpenAI adapter")
         return OpenAIAdapter()
 
-    if type(llm).__name__ == "AnthropicLLMService":
+    if llm_type == "AnthropicLLMService":
+        logger.debug("Creating Anthropic adapter")
         return AnthropicAdapter()
     
-    if type(llm).__name__ == "GoogleLLMService":
+    if llm_type == "GoogleLLMService":
+        logger.debug("Creating Google adapter")
         return GeminiAdapter()
 
     # If we get here, either the LLM type is not supported or the required dependency is not installed

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -201,13 +201,13 @@ class TestLLMAdapters(unittest.TestCase):
     def test_adapter_factory(self):
         """Test adapter creation based on LLM service type."""
         # Test with valid LLM services
-        openai_llm = MagicMock(spec=OpenAILLMService)
+        openai_llm = OpenAILLMService(api_key="")
         self.assertIsInstance(create_adapter(openai_llm), OpenAIAdapter)
 
-        anthropic_llm = MagicMock(spec=AnthropicLLMService)
+        anthropic_llm = AnthropicLLMService(api_key="")
         self.assertIsInstance(create_adapter(anthropic_llm), AnthropicAdapter)
 
-        gemini_llm = MagicMock(spec=GoogleLLMService)
+        gemini_llm = GoogleLLMService(api_key="")
         self.assertIsInstance(create_adapter(gemini_llm), GeminiAdapter)
 
     def test_adapter_factory_error_cases(self):

--- a/tests/test_context_strategies.py
+++ b/tests/test_context_strategies.py
@@ -42,7 +42,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         self.mock_task = AsyncMock()
 
         # Set up mock LLM with client
-        self.mock_llm = MagicMock(spec=OpenAILLMService)
+        self.mock_llm = OpenAILLMService(api_key="")
         self.mock_llm._client = MagicMock()
         self.mock_llm._client.chat = MagicMock()
         self.mock_llm._client.chat.completions = MagicMock()
@@ -195,7 +195,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         # Test OpenAI format
         flow_manager = FlowManager(
             task=self.mock_task,
-            llm=MagicMock(spec=OpenAILLMService),
+            llm=OpenAILLMService(api_key=""),
             context_aggregator=self.mock_context_aggregator,
         )
         openai_message = flow_manager.adapter.format_summary_message(summary)
@@ -204,7 +204,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         # Test Anthropic format
         flow_manager = FlowManager(
             task=self.mock_task,
-            llm=MagicMock(spec=AnthropicLLMService),
+            llm=AnthropicLLMService(api_key=""),
             context_aggregator=self.mock_context_aggregator,
         )
         anthropic_message = flow_manager.adapter.format_summary_message(summary)
@@ -213,7 +213,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         # Test Gemini format
         flow_manager = FlowManager(
             task=self.mock_task,
-            llm=MagicMock(spec=GoogleLLMService),
+            llm=GoogleLLMService(api_key=""),
             context_aggregator=self.mock_context_aggregator,
         )
         gemini_message = flow_manager.adapter.format_summary_message(summary)

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -45,7 +45,8 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         """Set up test fixtures before each test."""
         self.mock_task = AsyncMock()
-        self.mock_llm = MagicMock(spec=OpenAILLMService)
+        self.mock_llm = OpenAILLMService(api_key="")
+        self.mock_llm.register_function = MagicMock()
         self.mock_tts = AsyncMock()
 
         # Create mock context aggregator


### PR DESCRIPTION
As it was implemented, it was requiring devs to specify as pip requirements *all* optional LLM dependencies—google, anthropic, openai—regardless of which subset the dev actually needed.

The reason was that attempts to `import` from `pipecat.services.<llm>` would actually result in a different exception raised (`Exception(f"Missing module: {e}")`) than the one that was being handled (`ImportError`).

But something else was amiss here. By even *attempting* to `import` from an LLM service module we didn't need—say, `pipecat.services.anthropic`—we would inadvertently trigger some scary logger errors saying that the module and corresponding API key were missing, even though they're not needed.

It's worth noting there's no safety-related reason to import any LLM service modules here: if the dev has forgotten to install the appropriate dependency, they'll hit the error when trying to create the LLM service—e.g. `AnthropicLLMService`—in the first place.