### PR TITLE
Add support for function call start_callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for function `start_callback` to provide immediate feedback
+  before function execution.
+
+Example usage:
+
+```python
+# Define a start callback
+async def before_check_availability(function_name: str, llm: Any, context: Any) -> None:
+    """Provide user feedback during API calls."""
+    await llm.push_frame(TTSSpeakFrame("Let me check that for you..."))
+
+# Register in function configuration
+{
+    "type": "function",
+    "function": {
+        "name": "check_availability",
+        "handler": check_availability_handler,
+        "start_callback": before_check_availability,  # Add start callback
+        "description": "Check reservation availability",
+        "parameters": {...}
+    }
+}
+```
+
+### Other
+
+- Updated restaurant_reservation.py example to demonstrate the start callback
+  functionality.
+
 ## [0.0.15] - 2025-02-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@ Example usage:
 
 ```python
 # Define a start callback
-async def before_check_availability(function_name: str, llm: Any, context: Any) -> None:
+async def before_check_availability(function_name: str, flow_manager: FlowManager) -> None:
     """Provide user feedback during API calls."""
-    await llm.push_frame(TTSSpeakFrame("Let me check that for you..."))
+    await flow_manager.llm.push_frame(TTSSpeakFrame("Let me check that for you..."))
 
 # Register in function configuration
 {

--- a/examples/dynamic/restaurant_reservation.py
+++ b/examples/dynamic/restaurant_reservation.py
@@ -8,7 +8,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict
 
 import aiohttp
 from dotenv import load_dotenv
@@ -80,13 +80,13 @@ class TimeResult(FlowResult):
 
 
 # Start callback for availability check
-async def before_check_availability(function_name: str, llm: Any, context: Any) -> None:
+async def before_check_availability(function_name: str, flow_manager: FlowManager) -> None:
     """Provide feedback while checking availability.
 
     This is called before the availability check function executes.
     """
     logger.debug(f"Executing start callback for: {function_name}")
-    await llm.push_frame(TTSSpeakFrame("Let's see if we have an opening then..."))
+    await flow_manager.llm.push_frame(TTSSpeakFrame("Let's see if we have an opening then..."))
 
 
 # Function handlers

--- a/examples/dynamic/restaurant_reservation.py
+++ b/examples/dynamic/restaurant_reservation.py
@@ -7,14 +7,14 @@
 import asyncio
 import os
 import sys
-from datetime import datetime, time
 from pathlib import Path
-from typing import Dict, TypedDict
+from typing import Any, Dict
 
 import aiohttp
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -48,7 +48,7 @@ class MockReservationSystem:
     ) -> tuple[bool, list[str]]:
         """Check if a table is available for the given party size and time."""
         # Simulate API call delay
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(4.0)
 
         # Check if time is booked
         is_available = requested_time not in self.booked_times
@@ -77,6 +77,16 @@ class TimeResult(FlowResult):
     time: str
     available: bool
     alternative_times: list[str]
+
+
+# Start callback for availability check
+async def before_check_availability(function_name: str, llm: Any, context: Any) -> None:
+    """Provide feedback while checking availability.
+
+    This is called before the availability check function executes.
+    """
+    logger.debug(f"Executing start callback for: {function_name}")
+    await llm.push_frame(TTSSpeakFrame("Let's see if we have an opening then..."))
 
 
 # Function handlers
@@ -182,6 +192,7 @@ def create_time_selection_node() -> NodeConfig:
                 "function": {
                     "name": "check_availability",
                     "handler": check_availability,
+                    "start_callback": before_check_availability,
                     "description": "Check availability for requested time",
                     "parameters": {
                         "type": "object",
@@ -245,6 +256,7 @@ def create_no_availability_node(alternative_times: list[str]) -> NodeConfig:
                 "function": {
                     "name": "check_availability",
                     "handler": check_availability,
+                    "start_callback": before_check_availability,
                     "description": "Check availability for new time",
                     "parameters": {
                         "type": "object",

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -39,7 +39,6 @@ from pipecat.frames.frames import (
 from pipecat.pipeline.task import PipelineTask
 from pipecat.transports.base_transport import BaseTransport
 
-
 from .actions import ActionError, ActionManager
 from .adapters import create_adapter
 from .exceptions import FlowError, FlowInitializationError, FlowTransitionError
@@ -423,16 +422,18 @@ class FlowManager:
         handler: Optional[Callable],
         transition_to: Optional[str] = None,
         transition_callback: Optional[Callable] = None,
+        start_callback: Optional[Callable] = None,
     ) -> None:
         """Register a function with the LLM if not already registered.
 
         Args:
             name: Name of the function to register with the LLM
+            new_functions: Set to track newly registered functions for this node
             handler: Either a callable function or a string. If string starts with
                     '__function__:', extracts the function name after the prefix
             transition_to: Optional node name to transition to after function execution
             transition_callback: Optional callback for dynamic transitions
-            new_functions: Set to track newly registered functions for this node
+            start_callback: Optional callback to execute before function execution
 
         Raises:
             FlowError: If function registration fails or handler lookup fails
@@ -444,12 +445,14 @@ class FlowManager:
                     func_name = handler.split(":")[1]
                     handler = self._lookup_function(func_name)
 
-                self.llm.register_function(
-                    name,
-                    await self._create_transition_func(
-                        name, handler, transition_to, transition_callback
-                    ),
+                # Create transition function
+                transition_func = await self._create_transition_func(
+                    name, handler, transition_to, transition_callback
                 )
+
+                # Register function with LLM, including start_callback if present
+                self.llm.register_function(name, transition_func, start_callback=start_callback)
+
                 new_functions.add(name)
                 logger.debug(f"Registered function: {name}")
             except Exception as e:
@@ -486,6 +489,8 @@ class FlowManager:
                 del tool_config["function"]["transition_to"]
             if "transition_callback" in tool_config["function"]:
                 del tool_config["function"]["transition_callback"]
+            if "start_callback" in tool_config["function"]:
+                del tool_config["function"]["start_callback"]
         elif "function_declarations" in tool_config:
             # Clean Gemini format
             for decl in tool_config["function_declarations"]:
@@ -493,12 +498,16 @@ class FlowManager:
                     del decl["transition_to"]
                 if "transition_callback" in decl:
                     del decl["transition_callback"]
+                if "start_callback" in decl:
+                    del decl["start_callback"]
         else:
             # Clean Anthropic format
             if "transition_to" in tool_config:
                 del tool_config["transition_to"]
             if "transition_callback" in tool_config:
                 del tool_config["transition_callback"]
+            if "start_callback" in tool_config:
+                del tool_config["start_callback"]
 
     async def set_node(self, node_id: str, node_config: NodeConfig) -> None:
         """Set up a new conversation node and transition to it.
@@ -574,10 +583,12 @@ class FlowManager:
                         handler = func_config["function"].get("handler")
                         transition_to = func_config["function"].get("transition_to")
                         transition_callback = func_config["function"].get("transition_callback")
+                        start_callback = func_config["function"].get("start_callback")
                     else:
                         handler = func_config.get("handler")
                         transition_to = func_config.get("transition_to")
                         transition_callback = func_config.get("transition_callback")
+                        start_callback = func_config.get("start_callback")
 
                     await self._register_function(
                         name=name,
@@ -585,6 +596,7 @@ class FlowManager:
                         handler=handler,
                         transition_to=transition_to,
                         transition_callback=transition_callback,
+                        start_callback=start_callback,
                     )
 
                 # Create tool config (after removing handler and transition info)


### PR DESCRIPTION
Pipecat's LLMServices support a `start_callback` before a function call runs. This callback allows you to execute functionality before the LLM function call. It's handy when you want to push a frame or run functionality before the function call takes place.