### PR TITLE
Pass the FlowManager to function handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ async def before_check_availability(function_name: str, flow_manager: FlowManage
 }
 ```
 
+### Changed
+
+- Function handlers can now receive either `FlowArgs` only (legacy style) or
+  both `FlowArgs` and the `FlowManager` instance (modern style). Adding support
+  for the `FlowManager` provides access to conversation state, transport
+  methods, and other flow resources within function handlers. The framework
+  automatically detects which signature you're using and calls handlers
+  appropriately.
+
 ### Other
 
 - Updated restaurant_reservation.py example to demonstrate the start callback

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Dynamic flows follow the same pattern as static flows, but use `transition_callb
 
 ```python
 # Define handlers
-async def update_coverage(args: FlowArgs) -> FlowResult:
+async def update_coverage(args: FlowArgs, flow_manager: FlowManager) -> FlowResult:
     """Update coverage options; node function without a transition."""
     return {"coverage": args["coverage"]}
 

--- a/src/pipecat_flows/__init__.py
+++ b/src/pipecat_flows/__init__.py
@@ -68,7 +68,9 @@ from .types import (
     ContextStrategyConfig,
     FlowArgs,
     FlowConfig,
+    FlowFunctionHandler,
     FlowResult,
+    LegacyFunctionHandler,
     NodeConfig,
 )
 
@@ -80,7 +82,9 @@ __all__ = [
     "ContextStrategyConfig",
     "FlowArgs",
     "FlowConfig",
+    "FlowFunctionHandler",
     "FlowResult",
+    "LegacyFunctionHandler",
     "NodeConfig",
     # Exceptions
     "FlowError",

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -59,6 +59,31 @@ Example:
     }
 """
 
+LegacyFunctionHandler = Callable[[FlowArgs], Awaitable[FlowResult]]
+"""Legacy function handler that only receives arguments.
+
+Args:
+    args: Dictionary of arguments from the function call
+
+Returns:
+    FlowResult: Result of the function execution
+"""
+
+FlowFunctionHandler = Callable[[FlowArgs, "FlowManager"], Awaitable[FlowResult]]
+"""Modern function handler that receives both arguments and flow_manager.
+
+Args:
+    args: Dictionary of arguments from the function call
+    flow_manager: Reference to the FlowManager instance
+
+Returns:
+    FlowResult: Result of the function execution
+"""
+
+FunctionHandler = Union[LegacyFunctionHandler, FlowFunctionHandler]
+"""Union type for function handlers supporting both legacy and modern patterns."""
+
+
 LegacyActionHandler = Callable[[Dict[str, Any]], Awaitable[None]]
 """Legacy action handler type that only receives the action dictionary.
 


### PR DESCRIPTION
@kompfner this extends the pattern we discussed where the `FlowManager` should be generally available to different aspects of Flows. Let me know what you think.

I'm looking to preserve backwards compatibility for just providing `FlowArgs`, too.