### PR TITLE
Add a new "function" action type, which queues a function to run "inl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a new "function" action type, which queues a function to run "inline"
+  in the pipeline (i.e. when the pipeline is done with all the work queued
+  before it).
+
+  This is useful for doing things at the end of the bot's turn.
+
+  Example usage:
+
+  ```python
+  async def after_the_fun_fact(action: dict, flow_manager: FlowManager):
+    print("Done telling the user a fun fact.")
+
+  def create_node() -> NodeConfig:
+    return NodeConfig(
+      task_messages=[
+        {
+          "role": "system",
+          "content": "Greet the user and tell them a fun fact."
+        },
+        post_actions=[
+          ActionConfig(
+            type="function",
+            handler=after_the_fun_fact
+          )
+        ]
+      ]
+    )
+  ```
+
 - Added support for `OpenAILLMService` subclasses in the adapter system. You
   can now use any Pipecat LLM service that inherits from `OpenAILLMService`
   such as `AzureLLMService`, `GrokLLMService`, `GroqLLMService`, and other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio",
 ]
 dependencies = [
-    "pipecat-ai>=0.0.60",
+    "pipecat-ai>=0.0.61",
     "loguru~=0.7.2",
 ]
 

--- a/src/pipecat_flows/actions.py
+++ b/src/pipecat_flows/actions.py
@@ -78,6 +78,8 @@ class ActionManager:
         self._register_action("end_conversation", self._handle_end_action)
         self._register_action("function", self._handle_function_action)
 
+        # Wire up function actions
+        task.set_reached_downstream_filter((FunctionActionFrame,))
         @task.event_handler("on_frame_reached_downstream")
         async def on_frame_reached_downstream(task, frame):
             if isinstance(frame, FunctionActionFrame):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -21,7 +21,7 @@ mocked dependencies for PipelineTask and TTS service.
 
 import unittest
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from pipecat.frames.frames import EndFrame, TTSSpeakFrame
 
@@ -62,6 +62,7 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
         """
         self.mock_task = AsyncMock()
         self.mock_task.queue_frame = AsyncMock()
+        self.mock_task.event_handler = Mock()
 
         self.mock_tts = AsyncMock()
         self.mock_tts.say = AsyncMock()

--- a/tests/test_context_strategies.py
+++ b/tests/test_context_strategies.py
@@ -15,7 +15,7 @@ focusing on:
 """
 
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from pipecat.frames.frames import LLMMessagesAppendFrame, LLMMessagesUpdateFrame
 from pipecat.services.anthropic import AnthropicLLMService
@@ -40,6 +40,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         """Set up test fixtures before each test."""
         self.mock_task = AsyncMock()
+        self.mock_task.event_handler = Mock()
 
         # Set up mock LLM with client
         self.mock_llm = OpenAILLMService(api_key="")

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -20,7 +20,7 @@ include mocked dependencies for PipelineTask, LLM services, and TTS.
 
 import unittest
 from typing import Dict
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from pipecat.frames.frames import LLMMessagesAppendFrame, LLMMessagesUpdateFrame
 from pipecat.services.openai import OpenAILLMService
@@ -45,6 +45,7 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         """Set up test fixtures before each test."""
         self.mock_task = AsyncMock()
+        self.mock_task.event_handler = Mock()
         self.mock_llm = OpenAILLMService(api_key="")
         self.mock_llm.register_function = MagicMock()
         self.mock_tts = AsyncMock()


### PR DESCRIPTION
…ine" in the pipeline.

This is a new way of creating "custom" actions, and is what we should recommend unless someone intends to use the customer action to queue a frame themselves.

✅ This PR first requires [this change](https://github.com/pipecat-ai/pipecat/pull/1368) to land and be published, and for pipecat-flow's dependency on pipecat to be bumped to that published version.

✅ This PR is waiting on [this fix](https://github.com/pipecat-ai/pipecat/pull/1442) to land be published, and for pipecat-flow's dependency on pipecat to be bumped to that published version. The change has landed, but has not yet been published.