### PR TITLE
Return when flow changes during pre_actions

### DIFF
--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -581,10 +581,16 @@ class FlowManager:
                 for action in action_list:
                     self._register_action_from_config(action)
 
+            original_node = self.current_node
             # Execute pre-actions if any
             if pre_actions := node_config.get("pre_actions"):
                 await self._execute_actions(pre_actions=pre_actions)
-
+                if original_node != self.current_node:
+                    logger.debug(
+                        f"Node changed during pre-actions from {node_id} to {self.current_node}, exiting current set_node"
+                    )
+                    return
+                
             # Combine role and task messages
             messages = []
             if role_messages := node_config.get("role_messages"):

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -581,7 +581,7 @@ class FlowManager:
                 for action in action_list:
                     self._register_action_from_config(action)
 
-            original_node = self.current_node
+            original_node = self.current_node or node_id
             # Execute pre-actions if any
             if pre_actions := node_config.get("pre_actions"):
                 await self._execute_actions(pre_actions=pre_actions)


### PR DESCRIPTION
This PR suggests a change in pre-action allowing to call `flow_manager.set_node()` inside pre-action and perform an _early return_ on the other first `set_node` call. 

Consider this scenario where a pre-action changes the flow to a different node:

```python
async def check_and_redirect_user(action: dict, flow_manager: FlowManager) -> None:
    """Pre-action that checks user state and redirects to a different node if needed."""
    user_state = action.get("user_state", {})
    
    # If the user needs to be redirected to a different flow node
    if user_state.get("needs_onboarding"):
        logger.info("User needs onboarding, redirecting to onboarding node")
        # This call changes the current_node, but the original set_node would continue
        await flow_manager.set_node("onboarding", onboarding_node_config)
```

Then in a node configuration:

```python
def welcome_node() -> NodeConfig:
    """Welcome node that may redirect to onboarding."""
    return {
        "task_messages": [
            {
                "role": "user",
                "content": "Welcome to our service!"
            }
        ],
        "functions": [...],
        "pre_actions": [
            {
                "type": "check_user_state",
                "handler": check_and_redirect_user,
                "user_state": {"needs_onboarding": True}
            }
        ]
    }

# Usage in main code
await flow_manager.set_node("welcome", welcome_node())
```

With the fix, when `check_and_redirect_user` calls `set_node("onboarding", ...)`, the original `set_node("welcome", ...)` call detects the node change and returns early, preventing it from overwriting the context with the welcome node's configuration.
This ensures that when a pre-action explicitly changes nodes, we respect that decision and don't continue with the original node setup.

I particularly use it to run deterministic functions before, but sometimes I don't want to keep running the original `set_node`.