### PR TITLE
Revert: Add support for function call start_callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,32 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Added support for function `start_callback` to provide immediate feedback
-  before function execution.
-
-Example usage:
-
-```python
-# Define a start callback
-async def before_check_availability(function_name: str, flow_manager: FlowManager) -> None:
-    """Provide user feedback during API calls."""
-    await flow_manager.llm.push_frame(TTSSpeakFrame("Let me check that for you..."))
-
-# Register in function configuration
-{
-    "type": "function",
-    "function": {
-        "name": "check_availability",
-        "handler": check_availability_handler,
-        "start_callback": before_check_availability,  # Add start callback
-        "description": "Check reservation availability",
-        "parameters": {...}
-    }
-}
-```
-
 ### Changed
 
 - Function handlers can now receive either `FlowArgs` only (legacy style) or
@@ -43,9 +17,6 @@ async def before_check_availability(function_name: str, flow_manager: FlowManage
   appropriately.
 
 ### Other
-
-- Updated restaurant_reservation.py example to demonstrate the start callback
-  functionality.
 
 - Updated examples to specify a `params` arg for `PipelineTask`, meeting the
   Pipecat requirement starting 0.0.58.

--- a/examples/dynamic/restaurant_reservation.py
+++ b/examples/dynamic/restaurant_reservation.py
@@ -14,7 +14,6 @@ import aiohttp
 from dotenv import load_dotenv
 from loguru import logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.frames.frames import TTSSpeakFrame
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -48,7 +47,7 @@ class MockReservationSystem:
     ) -> tuple[bool, list[str]]:
         """Check if a table is available for the given party size and time."""
         # Simulate API call delay
-        await asyncio.sleep(4.0)
+        await asyncio.sleep(0.5)
 
         # Check if time is booked
         is_available = requested_time not in self.booked_times
@@ -77,16 +76,6 @@ class TimeResult(FlowResult):
     time: str
     available: bool
     alternative_times: list[str]
-
-
-# Start callback for availability check
-async def before_check_availability(function_name: str, flow_manager: FlowManager) -> None:
-    """Provide feedback while checking availability.
-
-    This is called before the availability check function executes.
-    """
-    logger.debug(f"Executing start callback for: {function_name}")
-    await flow_manager.llm.push_frame(TTSSpeakFrame("Let's see if we have an opening then..."))
 
 
 # Function handlers
@@ -192,7 +181,6 @@ def create_time_selection_node() -> NodeConfig:
                 "function": {
                     "name": "check_availability",
                     "handler": check_availability,
-                    "start_callback": before_check_availability,
                     "description": "Check availability for requested time",
                     "parameters": {
                         "type": "object",
@@ -256,7 +244,6 @@ def create_no_availability_node(alternative_times: list[str]) -> NodeConfig:
                 "function": {
                     "name": "check_availability",
                     "handler": check_availability,
-                    "start_callback": before_check_availability,
                     "description": "Check availability for new time",
                     "parameters": {
                         "type": "object",
@@ -320,7 +307,7 @@ async def main():
         stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
         tts = CartesiaTTSService(
             api_key=os.getenv("CARTESIA_API_KEY"),
-            voice_id="79a125e8-cd45-4c13-8a67-188112f4dd22",
+            voice_id="71a7ad14-091c-4e8e-a314-022ece01c121",
         )
         llm = OpenAILLMService(api_key=os.getenv("OPENAI_API_KEY"), model="gpt-4o")
 

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -444,7 +444,6 @@ class FlowManager:
         handler: Optional[Callable],
         transition_to: Optional[str] = None,
         transition_callback: Optional[Callable] = None,
-        start_callback: Optional[Callable] = None,
     ) -> None:
         """Register a function with the LLM if not already registered.
 
@@ -455,7 +454,6 @@ class FlowManager:
                     '__function__:', extracts the function name after the prefix
             transition_to: Optional node name to transition to after function execution
             transition_callback: Optional callback for dynamic transitions
-            start_callback: Optional callback to execute before function execution
 
         Raises:
             FlowError: If function registration fails or handler lookup fails
@@ -467,27 +465,15 @@ class FlowManager:
                     func_name = handler.split(":")[1]
                     handler = self._lookup_function(func_name)
 
-                # Create the wrapper for the start_callback that passes flow_manager
-                async def start_callback_wrapper(
-                    function_name: str, llm: Any, context: Any
-                ) -> None:
-                    if start_callback:
-                        try:
-                            # Pass flow_manager instead of llm and context
-                            await start_callback(function_name, self)
-                        except Exception as e:
-                            logger.error(f"Error in start callback for {name}: {str(e)}")
-
                 # Create transition function
                 transition_func = await self._create_transition_func(
                     name, handler, transition_to, transition_callback
                 )
 
-                # Register function with LLM, including start_callback if present
+                # Register function with LLM
                 self.llm.register_function(
                     name,
                     transition_func,
-                    start_callback=start_callback_wrapper if start_callback else None,
                 )
 
                 new_functions.add(name)
@@ -526,8 +512,6 @@ class FlowManager:
                 del tool_config["function"]["transition_to"]
             if "transition_callback" in tool_config["function"]:
                 del tool_config["function"]["transition_callback"]
-            if "start_callback" in tool_config["function"]:
-                del tool_config["function"]["start_callback"]
         elif "function_declarations" in tool_config:
             # Clean Gemini format
             for decl in tool_config["function_declarations"]:
@@ -535,16 +519,12 @@ class FlowManager:
                     del decl["transition_to"]
                 if "transition_callback" in decl:
                     del decl["transition_callback"]
-                if "start_callback" in decl:
-                    del decl["start_callback"]
         else:
             # Clean Anthropic format
             if "transition_to" in tool_config:
                 del tool_config["transition_to"]
             if "transition_callback" in tool_config:
                 del tool_config["transition_callback"]
-            if "start_callback" in tool_config:
-                del tool_config["start_callback"]
 
     async def set_node(self, node_id: str, node_config: NodeConfig) -> None:
         """Set up a new conversation node and transition to it.
@@ -620,12 +600,10 @@ class FlowManager:
                         handler = func_config["function"].get("handler")
                         transition_to = func_config["function"].get("transition_to")
                         transition_callback = func_config["function"].get("transition_callback")
-                        start_callback = func_config["function"].get("start_callback")
                     else:
                         handler = func_config.get("handler")
                         transition_to = func_config.get("transition_to")
                         transition_callback = func_config.get("transition_callback")
-                        start_callback = func_config.get("start_callback")
 
                     await self._register_function(
                         name=name,
@@ -633,7 +611,6 @@ class FlowManager:
                         handler=handler,
                         transition_to=transition_to,
                         transition_callback=transition_callback,
-                        start_callback=start_callback,
                     )
 
                 # Create tool config (after removing handler and transition info)


### PR DESCRIPTION
`start_callback` is deprecated in Pipecat, so I'm removing it before it gets released.