### PR TITLE
Support waiting until user speaks attempt 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added `respond_immediately` to `NodeConfig`. Setting it to `False` has the effect of making the
+  bot wait, after the node is activated, for the user to speak before responding.
+
 - Bumped the minimum required `pipecat-ai` version to 0.0.67 to align with AWS
   Bedrock additions in Pipecat. This also adds support for `FunctionCallParams`
   which were added in 0.0.66.

--- a/examples/dynamic/restaurant_reservation.py
+++ b/examples/dynamic/restaurant_reservation.py
@@ -180,7 +180,7 @@ def create_initial_node(wait_for_user: bool) -> NodeConfig:
         "task_messages": [
             {
                 "role": "system",
-                "content": "Warmly greet the customer and ask how many people are in their party. This is your only job for now; if the customer has asked for something else, politely remind them you can't do it.",
+                "content": "Warmly greet the customer and ask how many people are in their party. This is your only job for now; if the customer asks for something else, politely remind them you can't do it.",
             }
         ],
         "functions": [party_size_schema],

--- a/examples/dynamic/restaurant_reservation.py
+++ b/examples/dynamic/restaurant_reservation.py
@@ -180,7 +180,7 @@ def create_initial_node(wait_for_user: bool) -> NodeConfig:
         "task_messages": [
             {
                 "role": "system",
-                "content": "Warmly greet the customer and ask how many people are in their party.",
+                "content": "Warmly greet the customer and ask how many people are in their party. This is your only job for now; if the customer has asked for something else, politely remind them you can't do it.",
             }
         ],
         "functions": [party_size_schema],

--- a/examples/runner.py
+++ b/examples/runner.py
@@ -8,7 +8,11 @@ import argparse
 import os
 
 import aiohttp
-from pipecat.transports.services.helpers.daily_rest import DailyRESTHelper, DailyMeetingTokenParams, DailyMeetingTokenProperties
+from pipecat.transports.services.helpers.daily_rest import (
+    DailyMeetingTokenParams,
+    DailyMeetingTokenProperties,
+    DailyRESTHelper,
+)
 
 
 async def configure(aiohttp_session: aiohttp.ClientSession):
@@ -58,11 +62,9 @@ async def configure_with_args(
     expiry_time: float = 60 * 60
 
     token = await daily_rest_helper.get_token(
-        url, 
-        expiry_time, 
-        params=DailyMeetingTokenParams(properties=DailyMeetingTokenProperties(
-            user_id="bot"
-        ))
+        url,
+        expiry_time,
+        params=DailyMeetingTokenParams(properties=DailyMeetingTokenProperties(user_id="bot")),
     )
 
     return (url, token, args)

--- a/src/pipecat_flows/actions.py
+++ b/src/pipecat_flows/actions.py
@@ -22,17 +22,17 @@ Actions are used to perform side effects during conversations, such as:
 """
 
 import asyncio
-from dataclasses import dataclass
 import inspect
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional
 
 from loguru import logger
 from pipecat.frames.frames import (
+    ControlFrame,
     EndFrame,
     TTSSpeakFrame,
 )
 from pipecat.pipeline.task import PipelineTask
-from pipecat.frames.frames import ControlFrame
 
 from .exceptions import ActionError
 from .types import ActionConfig, FlowActionHandler
@@ -81,6 +81,7 @@ class ActionManager:
 
         # Wire up function actions
         task.set_reached_downstream_filter((FunctionActionFrame,))
+
         @task.event_handler("on_frame_reached_downstream")
         async def on_frame_reached_downstream(task, frame):
             if isinstance(frame, FunctionActionFrame):
@@ -209,7 +210,7 @@ class ActionManager:
         if not handler:
             logger.error("Function action missing 'handler' field")
             return
-        # the reason we're queueing a frame here is to ensure it happens after bot turn is over in 
+        # the reason we're queueing a frame here is to ensure it happens after bot turn is over in
         # post_actions
         await self.task.queue_frame(FunctionActionFrame(action=action, function=handler))
         await self.function_finished_event.wait()

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -558,7 +558,7 @@ class FlowManager:
             self.current_functions = new_functions
 
             # Trigger completion with new context
-            if self._context_aggregator:
+            if self._context_aggregator and node_config.get("respond_immediately", True):
                 await self.task.queue_frames([self._context_aggregator.user().get_context_frame()])
 
             # Execute post-actions if any

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -228,6 +228,7 @@ class NodeConfig(NodeConfigRequired, total=False):
         pre_actions: Actions to execute before LLM inference
         post_actions: Actions to execute after LLM inference
         context_strategy: Strategy for updating context during transitions
+        respond_immediately: Whether to run LLM inference as soon as the node is set (default: True)
 
     Example:
         {
@@ -254,6 +255,7 @@ class NodeConfig(NodeConfigRequired, total=False):
     pre_actions: List[ActionConfig]
     post_actions: List[ActionConfig]
     context_strategy: ContextStrategyConfig
+    respond_immediately: bool
 
 
 class FlowConfig(TypedDict):


### PR DESCRIPTION
This PR is the same as the now-reverted https://github.com/pipecat-ai/pipecat-flows/pull/128, but with [an additional change](https://github.com/pipecat-ai/pipecat-flows/pull/133/commits/29a403199d4fcee57f5315a69b5974ad2dc3280e) to ensure that `post_actions` (which today really behave like, and probably should be named, `post_first_response_actions`) run at the appropriate time: after the bot's first response in the node.

Here's the accompanying docs PR: https://github.com/pipecat-ai/docs/pull/236