### PR TITLE
Fix the warm transfer demo's hold music player, which stopped working…

### DIFF
--- a/examples/assets/hold_music/hold_music.py
+++ b/examples/assets/hold_music/hold_music.py
@@ -1,12 +1,13 @@
 #
 # This demo will join a Daily meeting and send the audio from a WAV file into
-# the meeting.
+# the meeting. It uses the asyncio library.
 #
-# Usage: python3 wav_audio_send.py -m MEETING_URL -i FILE.wav
+# Usage: python3 hold_music.py -m MEETING_URL -i FILE.wav
 #
 
 import argparse
-import threading
+import asyncio
+import signal
 import wave
 
 from daily import *
@@ -15,10 +16,13 @@ SAMPLE_RATE = 16000
 NUM_CHANNELS = 1
 
 
-class SendWavApp:
+class AsyncSendWavApp:
     def __init__(self, input_file_name, sample_rate, num_channels):
         self.__mic_device = Daily.create_microphone_device(
-            "my-mic", sample_rate=sample_rate, channels=num_channels
+            "my-mic",
+            sample_rate=sample_rate,
+            channels=num_channels,
+            non_blocking=True,
         )
 
         self.__client = CallClient()
@@ -27,20 +31,28 @@ class SendWavApp:
             {"base": {"camera": "unsubscribed", "microphone": "unsubscribed"}}
         )
 
-        self.__app_quit = False
         self.__app_error = None
 
-        self.__start_event = threading.Event()
-        self.__thread = threading.Thread(target=self.send_wav_file, args=[input_file_name])
-        self.__thread.start()
+        self.__start_event = asyncio.Event()
+        self.__task = asyncio.get_running_loop().create_task(self.send_wav_file(input_file_name))
 
-    def on_joined(self, data, error):
+    async def run(self, meeting_url, meeting_token):
+        (data, error) = await self.join(meeting_url, meeting_token)
+
         if error:
             print(f"Unable to join meeting: {error}")
             self.__app_error = error
+
         self.__start_event.set()
 
-    def run(self, meeting_url, meeting_token):
+        await self.__task
+
+    async def join(self, meeting_url, meeting_token):
+        future = asyncio.get_running_loop().create_future()
+
+        def join_completion(data, error):
+            future.get_loop().call_soon_threadsafe(future.set_result, (data, error))
+
         self.__client.join(
             meeting_url,
             meeting_token,
@@ -50,37 +62,65 @@ class SendWavApp:
                     "microphone": {"isEnabled": True, "settings": {"deviceId": "my-mic"}},
                 }
             },
-            completion=self.on_joined,
+            completion=join_completion,
         )
-        self.__thread.join()
 
-    def leave(self):
-        self.__app_quit = True
-        self.__thread.join()
-        self.__client.leave()
+        return await future
+
+    async def leave(self):
+        future = asyncio.get_running_loop().create_future()
+
+        def leave_completion(error):
+            future.get_loop().call_soon_threadsafe(future.set_result, error)
+
+        self.__client.leave(completion=leave_completion)
+
+        await future
+
         self.__client.release()
 
-    def send_wav_file(self, file_name):
-        self.__start_event.wait()
+        self.__task.cancel()
+        await self.__task
+
+    async def write_frames(self, frames):
+        future = asyncio.get_running_loop().create_future()
+
+        def write_completion(count):
+            future.get_loop().call_soon_threadsafe(future.set_result, count)
+
+        self.__mic_device.write_frames(frames, completion=write_completion)
+
+        await future
+
+    async def send_wav_file(self, file_name):
+        await self.__start_event.wait()
 
         if self.__app_error:
             print(f"Unable to send WAV file!")
             return
 
-        wav = wave.open(file_name, "rb")
+        try:
+            wav = wave.open(file_name, "rb")
 
-        sent_frames = 0
-        total_frames = wav.getnframes()
-        sample_rate = wav.getframerate()
-        while not self.__app_quit and sent_frames < total_frames:
-            # Read 100ms worth of audio frames.
-            frames = wav.readframes(int(sample_rate / 10))
-            if len(frames) > 0:
-                self.__mic_device.write_frames(frames)
-                sent_frames += sample_rate / 10
+            sent_frames = 0
+            total_frames = wav.getnframes()
+            sample_rate = wav.getframerate()
+            while sent_frames < total_frames:
+                # Read 100ms worth of audio frames.
+                frames = wav.readframes(int(sample_rate / 10))
+                if len(frames) > 0:
+                    await self.write_frames(frames)
+                    sent_frames += sample_rate / 10
+        except asyncio.CancelledError:
+            pass
 
 
-def main():
+async def sig_handler(app):
+    print("Ctrl-C detected. Exiting!")
+    await app.leave()
+
+
+async def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--meeting", required=True, help="Meeting URL")
     parser.add_argument("-t", "--token", required=True, help="Meeting token")
@@ -94,15 +134,14 @@ def main():
 
     Daily.init()
 
-    app = SendWavApp(args.input, args.rate, args.channels)
+    app = AsyncSendWavApp(args.input, args.rate, args.channels)
 
-    try:
-        app.run(args.meeting, args.token)
-    except KeyboardInterrupt:
-        print("Ctrl-C detected. Exiting!")
-    finally:
-        app.leave()
+    loop = asyncio.get_running_loop()
+
+    loop.add_signal_handler(signal.SIGINT, lambda *args: asyncio.create_task(sig_handler(app)))
+
+    await app.run(args.meeting, args.token)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
… with daily-python 0.18.0.

The "fix" is actually just a workaround: the hold music player is now based on daily-python's `AsyncSendWavApp` example rather than `SendWaveApp`, which seems to have stopped working with daily-python 0.18.0.