### PR TITLE
Fix: Removes Repeated LLM Calls After Parallel Tool Calls

### DIFF
--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -370,7 +370,7 @@ class FlowManager:
                         await on_context_updated_node()
 
                 properties = FunctionCallResultProperties(
-                    run_llm=not is_edge_function,
+                    run_llm=False if is_edge_function else None,
                     on_context_updated=on_context_updated,
                 )
                 await params.result_callback(result, properties=properties)


### PR DESCRIPTION
Parallel tool calls result in repetition by the LLM after each result is returned. This patch just allows the main fix in 
https://github.com/pipecat-ai/pipecat/pull/1683 to do it's thing.