### PR TITLE
Fix `TestContextStrategies.test_provider_specific_summary_formatting`…

### DIFF
--- a/tests/test_context_strategies.py
+++ b/tests/test_context_strategies.py
@@ -215,7 +215,7 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         # Test Gemini format
         flow_manager = FlowManager(
             task=self.mock_task,
-            llm=GoogleLLMService(api_key=""),
+            llm=GoogleLLMService(api_key=" "), # dummy key (GoogleLLMService rejects empty string)
             context_aggregator=self.mock_context_aggregator,
         )
         gemini_message = flow_manager.adapter.format_summary_message(summary)


### PR DESCRIPTION
… unit test, which is broken when used with Pipecat versions 0.0.68 and above