### PR TITLE
Fix: Handle run_in_parallel=False, simplify pending function call tra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you to either omit `functions` for nodes, which is common for the end node,
   or specify an empty function call list, if desired.
 
+### Fixed
+
+- Fixed an issue where if run_in_parallel=False was set for the LLM, the bot
+  would trigger N completions for each sequential function call. Now, Flows
+  uses Pipecat's internal function tracking to determine when there are more
+  edge functions to call.
+
 ## [0.0.17] - 2025-05-16
 
 ### Added


### PR DESCRIPTION
…cking

This is going to conflict with #141 but I wanted to work through how to fix this problem given the current code. We can figure out how to make this work with the new logic, as it offers a way to simplify the logic overall.

Crucially, this defers the pending function calling logic to Pipecat, which offers a means for Pipecat Flows to be simplified.

cc @kompfner happy to discuss!