### PR TITLE
Fix editor flow

### DIFF
--- a/editor/js/utils/export.js
+++ b/editor/js/utils/export.js
@@ -62,6 +62,7 @@ export function generateFlowConfig(graphInstance) {
           // Create base function configuration
           const funcConfig = {
             type: "function",
+            name: targetNode.properties.function.name,
             function: { ...targetNode.properties.function },
           };
 


### PR DESCRIPTION
Previous exporting schema lead to error : 

```
Traceback (most recent call last):
  File ".../pipecat_flows/manager.py", line 665, in _set_node
    else self.adapter.convert_to_function_schema(func_config)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../pipecat_flows/adapters.py", line 517, in convert_to_function_schema
    name = decl["name"]
           ~~~~^^^^^^^^
KeyError: 'name'

pipecat_flows.exceptions.FlowInitializationError: Failed to initialize flow: Failed to set node PipecatStartNode: 'name'
```

Adding name to function on export. 
