### PR TITLE
Add reference docs, docstring linting, and docstring updates

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,46 @@
+name: format
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'docs/**'
+
+concurrency:
+  group: build-format-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff-format:
+    name: 'Code quality checks'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Setup virtual environment
+        run: |
+          python -m venv .venv
+      - name: Install development Python dependencies
+        run: |
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+      - name: Ruff formatter
+        id: ruff-format
+        run: |
+          source .venv/bin/activate
+          ruff format --diff
+      - name: Ruff linter (docstrings and imports)
+        id: ruff-check
+        run: |
+          source .venv/bin/activate
+          ruff check --select D,I

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -39,8 +39,8 @@ jobs:
         run: |
           source .venv/bin/activate
           ruff format --diff
-      - name: Ruff linter (docstrings and imports)
+      - name: Ruff linter (all rules)
         id: ruff-check
         run: |
           source .venv/bin/activate
-          ruff check --select D,I
+          ruff check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Cache virtual environment
         uses: actions/cache@v3
         with:
-          key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version}}-${{ hashFiles('dev-requirements.txt') }}-${{ hashFiles('test-requirements.txt') }}
+          key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version}}-${{ hashFiles('dev-requirements.txt') }}
           path: .venv
 
       - name: Setup virtual environment
@@ -41,7 +41,7 @@ jobs:
         run: |
           source .venv/bin/activate
           python -m pip install --upgrade pip
-          pip install -r dev-requirements.txt -r test-requirements.txt
+          pip install -r dev-requirements.txt
           pip uninstall -y google-generativeai google-genai google-ai-generativelanguage
           pip install "google-genai==0.7.0"
           pip install "pipecat-ai[google,openai,anthropic]"

--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,9 @@ npm-debug.log*
 *.sln
 *.sw?
 
-# JSDoc documentation
-docs/
-
+# Auto-generated docs
+docs/api
+docs/_build/
 
 # Python
 __pycache__/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.7
+    hooks:
+      - id: ruff
+        language_version: python3
+        args: [--select, D, I]
+      - id: ruff-format

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.12'
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,10 +26,166 @@ git commit -m "Description of your changes"
 git push origin your-branch-name
 ```
 
-9. **Submit a Pull Request (PR)**: Open a PR from your forked repository to the main branch of this repo.
+8. **Submit a Pull Request (PR)**: Open a PR from your forked repository to the main branch of this repo.
    > Important: Describe the changes you've made clearly!
 
 Our maintainers will review your PR, and once everything is good, your contributions will be merged!
+
+## Code Style and Documentation
+
+### Python Code Style
+
+We use Ruff for code linting and formatting. Please ensure your code passes all linting checks before submitting a PR.
+
+### Docstring Conventions
+
+We follow Google-style docstrings with these specific conventions:
+
+**Regular Classes:**
+
+- Class docstring describes the class purpose and key functionality
+- `__init__` method has its own docstring with complete `Args:` section documenting all parameters
+- All public methods must have docstrings with `Args:` and `Returns:` sections as appropriate
+
+**Dataclasses:**
+
+- Class docstring describes the purpose and documents all fields in a `Parameters:` section
+- No `__init__` docstring (auto-generated)
+
+**Properties:**
+
+- Must have docstrings with `Returns:` section
+
+**Abstract Methods:**
+
+- Must have docstrings explaining what subclasses should implement
+
+**`__init__.py` Files:**
+
+- **Skip docstrings** for pure import/re-export modules
+- **Add brief docstrings** for top-level packages or those with initialization logic
+
+**Enums:**
+
+- Class docstring describes the enumeration purpose
+- Use `Parameters:` section to document each enum value and its meaning
+- No `__init__` docstring (Enums don't have custom constructors)
+
+**Code Examples in Docstrings:**
+
+- Use `Examples:` as a section header for multiple examples
+- Use descriptive text followed by double colons (`::`) for each example
+- **Always include a blank line after the `::"`**
+- Indent all code consistently within each block
+- Separate multiple examples with blank lines for readability
+
+**Lists and Bullets in Docstrings:**
+
+- Use dashes (`-`) for bullet points, not asterisks (`*`)
+- **Add a blank line before bullet lists** when they follow a colon
+- Use section headers like "Supported features:" or "Behavior:" before lists
+- For complex nested information, consider using paragraph format instead
+
+**Deprecations:**
+
+- Use `warnings.warn()` in code for runtime deprecation warnings
+- Add `.. deprecated::` directive in docstrings for documentation visibility
+- Include version information and describe current status
+- Describe parameters in present tense, use directive to indicate deprecation status
+
+#### Examples:
+
+```python
+# Regular class
+class MyService(BaseService):
+    """Description of what the service does.
+
+    Provides detailed explanation of the service's functionality,
+    key features, and usage patterns.
+
+    Supported features:
+
+    - Feature one with detailed explanation
+    - Feature two with additional context
+    - Feature three for advanced use cases
+    """
+
+    def __init__(self, param1: str, old_param: str = None, **kwargs):
+        """Initialize the service.
+
+        Args:
+            param1: Description of param1.
+            old_param: Controls legacy behavior.
+
+                .. deprecated:: 1.2.0
+                    This parameter no longer has any effect and will be removed in version 2.0.
+
+            **kwargs: Additional arguments passed to parent.
+        """
+        if old_param is not None:
+            import warnings
+            warnings.warn(
+                "Parameter 'old_param' is deprecated and will be removed in version 2.0.",
+                DeprecationWarning,
+            )
+        super().__init__(**kwargs)
+
+    @property
+    def sample_rate(self) -> int:
+        """Get the current sample rate.
+
+        Returns:
+            The sample rate in Hz.
+        """
+        return self._sample_rate
+
+    async def process_data(self, data: str) -> bool:
+        """Process the provided data.
+
+        Args:
+            data: The data to process.
+
+        Returns:
+            True if processing succeeded.
+        """
+        pass
+
+# Dataclass with code examples
+@dataclass
+class MessageFrame:
+    """Frame containing messages in OpenAI format.
+
+    Supports both simple and content list message formats.
+
+    Example::
+
+        [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"}
+        ]
+
+    Parameters:
+        messages: List of messages in OpenAI format.
+    """
+
+    messages: List[dict]
+
+# Enum class
+class Status(Enum):
+    """Status codes for processing operations.
+
+    Parameters:
+        PENDING: Operation is queued but not started.
+        RUNNING: Operation is currently in progress.
+        COMPLETED: Operation finished successfully.
+        FAILED: Operation encountered an error.
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+```
 
 # Contributor Covenant Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ The package includes a comprehensive test suite covering the core functionality.
 
 2. **Install Test Dependencies**:
    ```bash
-   pip install -r dev-requirements.txt -r test-requirements.txt
+   pip install -r dev-requirements.txt
    pip install "pipecat-ai[google,openai,anthropic]"
    pip install -e .
    ```

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ The framework consists of:
 ## Installation
 
 Setup virtual environment
+
 ```bash
 python3 -m venv venv
 source venv/bin/activate
 ```
 
 Install
+
 ```bash
 pip install pipecat-ai-flows
 ```
@@ -505,6 +507,35 @@ To run these examples:
    ```bash
    python examples/static/food_ordering.py -u YOUR_DAILY_ROOM_URL
    ```
+
+## Hacking on the framework
+
+1. Set up a virtual environment before following these instructions. From the root of the repo:
+
+   ```shell
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+2. Install the development dependencies:
+
+   ```shell
+   pip install -r dev-requirements.txt
+   ```
+
+3. Install the git pre-commit hooks (these help ensure your code follows project rules):
+
+   ```shell
+   pre-commit install
+   ```
+
+4. Install the `pipecat-ai-flows` package locally in editable mode:
+
+   ```shell
+   pip install -e .
+   ```
+
+   > The `-e` or `--editable` option allows you to modify the code without reinstalling.
 
 ## Tests
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 build~=1.2.2
 pip-tools~=7.4.1
+pre-commit~=4.2.0
 pytest~=8.4.1
 pytest-asyncio~=1.0.0
 pytest-cov~=4.1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,8 @@
-build~=1.2.1
+build~=1.2.2
 pip-tools~=7.4.1
-pytest~=8.3.2
-pytest-asyncio~=0.23.5
+pytest~=8.4.1
+pytest-asyncio~=1.0.0
 pytest-cov~=4.1.0
-ruff~=0.9.1
-setuptools~=72.2.0
-python-dotenv~=1.0.1
+ruff~=0.12.1
+setuptools~=78.1.1
+python-dotenv~=1.1.1

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean previous build
+rm -rf _build
+
+# Build docs matching ReadTheDocs configuration
+sphinx-build -b html -d _build/doctrees . _build/html -W --keep-going
+
+# Open docs (MacOS)
+open _build/html/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,155 @@
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("sphinx-build")
+
+# Add source directory to path
+docs_dir = Path(__file__).parent
+project_root = docs_dir.parent
+sys.path.insert(0, str(project_root / "src"))
+
+# Project information
+project = "pipecat-ai-flows"
+current_year = datetime.now().year
+copyright = f"2024-{current_year}, Daily" if current_year > 2024 else "2024, Daily"
+author = "Daily"
+
+# General configuration
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+]
+
+# Suppress warnings about mocked objects
+suppress_warnings = [
+    "autodoc.mocked_object",
+]
+
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_include_init_with_doc = True
+
+# AutoDoc settings
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "undoc-members": True,
+    "exclude-members": "__weakref__",
+    "no-index": True,
+    "show-inheritance": True,
+}
+
+# Mock imports for optional dependencies (if any)
+autodoc_mock_imports = [
+    # Add any optional dependencies here that might not be available during doc builds
+]
+
+# Intersphinx mapping
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "pipecat": ("https://docs.pipecat.ai/api", None),
+}
+
+# HTML output settings
+html_theme = "sphinx_rtd_theme"
+html_static_path = ["_static"]
+autodoc_typehints = "signature"
+html_show_sphinx = False
+
+
+def clean_title(title: str) -> str:
+    """Automatically clean module titles."""
+    # Remove everything after space (like 'module', 'processor', etc.)
+    title = title.split(" ")[0]
+
+    # Get the last part of the dot-separated path
+    parts = title.split(".")
+    title = parts[-1]
+
+    # Special cases for common terms
+    special_cases = {
+        "ai": "AI",
+        "flows": "Flows",
+    }
+
+    # Check if the entire title is a special case
+    if title.lower() in special_cases:
+        return special_cases[title.lower()]
+
+    # Otherwise, capitalize each word
+    words = title.split("_")
+    cleaned_words = []
+    for word in words:
+        if word.lower() in special_cases:
+            cleaned_words.append(special_cases[word.lower()])
+        else:
+            cleaned_words.append(word.capitalize())
+
+    return " ".join(cleaned_words)
+
+
+def setup(app):
+    """Generate API documentation during Sphinx build."""
+    from sphinx.ext.apidoc import main
+
+    docs_dir = Path(__file__).parent
+    project_root = docs_dir.parent
+    output_dir = str(docs_dir / "api")
+    source_dir = str(project_root / "src" / "pipecat_flows")
+
+    # Clean existing files
+    if Path(output_dir).exists():
+        import shutil
+
+        shutil.rmtree(output_dir)
+        logger.info(f"Cleaned existing documentation in {output_dir}")
+
+    logger.info(f"Generating API documentation...")
+    logger.info(f"Output directory: {output_dir}")
+    logger.info(f"Source directory: {source_dir}")
+
+    excludes = [
+        "**/test_*.py",
+        "**/tests/*.py",
+    ]
+
+    try:
+        main(
+            [
+                "-f",  # Force overwriting
+                "-e",  # Don't generate empty files
+                "-M",  # Put module documentation before submodule documentation
+                "--no-toc",  # Don't create a table of contents file
+                "--separate",  # Put documentation for each module in its own page
+                "--module-first",  # Module documentation before submodule documentation
+                "--implicit-namespaces",  # Handle implicit namespace packages
+                "-o",
+                output_dir,
+                source_dir,
+            ]
+            + excludes
+        )
+
+        logger.info("API documentation generated successfully!")
+
+        # Process generated RST files to update titles
+        for rst_file in Path(output_dir).glob("**/*.rst"):
+            content = rst_file.read_text()
+            lines = content.split("\n")
+
+            # Find and clean up the title
+            if lines and len(lines) > 1 and "=" in lines[1]:
+                old_title = lines[0]
+                new_title = clean_title(old_title)
+                content = content.replace(old_title, new_title)
+                rst_file.write_text(content)
+                logger.info(f"Updated title: {old_title} -> {new_title}")
+
+    except Exception as e:
+        logger.error(f"Error generating API documentation: {e}", exc_info=True)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,25 @@
+Pipecat Flows API Reference
+===========================
+
+Welcome to the Pipecat Flows API reference documentation!
+
+Pipecat Flows is a conversation flow management add-on for Pipecat AI applications,
+enabling sophisticated state-driven conversational experiences with conditional
+logic, flow transitions, and context management.
+
+Quick Links
+-----------
+
+* `GitHub Repository <https://github.com/pipecat-ai/pipecat-flows>`_
+* `Main Pipecat Documentation <https://docs.pipecat.ai>`_
+
+.. toctree::
+   :maxdepth: 3
+   :caption: API Reference
+   :hidden:
+
+   Actions <api/pipecat_flows.actions>
+   Adapters <api/pipecat_flows.adapters>
+   Exceptions <api/pipecat_flows.exceptions>
+   Manager <api/pipecat_flows.manager>
+   Types <api/pipecat_flows.types>

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,9 @@
+# Sphinx dependencies
+sphinx>=8.1.3
+sphinx-rtd-theme
+sphinx-markdown-builder
+sphinx-autodoc-typehints
+toml
+
+# Pipecat Flows dependencies
+pipecat-ai-flows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ ignore = [
 # Skip docstring checks for non-source code
 "examples/**/*.py" = ["D"]
 "tests/**/*.py" = ["D"]
+"docs/**/*.py" = ["D"]
 # Skip D104 (missing docstring in public package) for __init__.py files
 "**/__init__.py" = ["D104"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,6 @@ ignore = [
 "examples/**/*.py" = ["D"]
 "tests/**/*.py" = ["D"]
 "docs/**/*.py" = ["D"]
-# Skip D104 (missing docstring in public package) for __init__.py files
-"**/__init__.py" = ["D104"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,5 @@ ignore = [
 "tests/**/*.py" = ["D"]
 "docs/**/*.py" = ["D"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 
 [tool.ruff]
-exclude = [".git", "*_pb2.py"]
+exclude = [".git"]
 line-length = 100
 
 [tool.ruff.lint]
@@ -42,6 +42,16 @@ select = [
     "D", # Docstring rules
     "I", # Import rules
 ]
+ignore = [
+    "D105",  # Missing docstring in magic methods (__str__, __repr__, etc.)
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Skip docstring checks for non-source code
+"examples/**/*.py" = ["D"]
+"tests/**/*.py" = ["D"]
+# Skip D104 (missing docstring in public package) for __init__.py files
+"**/__init__.py" = ["D104"]
 
 [tool.ruff.pydocstyle]
 convention = "google"

--- a/scripts/fix-ruff.sh
+++ b/scripts/fix-ruff.sh
@@ -1,5 +1,9 @@
-ruff format src
-ruff format examples
-ruff format tests
-ruff format scripts
-ruff check --select I,D --fix
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "Running ruff format..."
+ruff format "$PROJECT_ROOT"
+echo "Running ruff check..."
+ruff check --select I,D --fix "$PROJECT_ROOT"

--- a/scripts/fix-ruff.sh
+++ b/scripts/fix-ruff.sh
@@ -1,0 +1,5 @@
+ruff format src
+ruff format examples
+ruff format tests
+ruff format scripts
+ruff check --select I,D --fix

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+echo "🔍 Running pre-commit checks..."
+
+# Change to project root (one level up from scripts/)
+cd "$(dirname "$0")/.."
+
+# Format check
+echo "📝 Checking code formatting..."
+if ! NO_COLOR=1 ruff format --diff --check; then
+    echo -e "${RED}❌ Code formatting issues found. Run 'ruff format' to fix.${NC}"
+    exit 1
+fi
+
+# Lint check
+echo "🔍 Running linter..."
+if ! ruff check; then
+    echo -e "${RED}❌ Linting issues found.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ All pre-commit checks passed!${NC}"

--- a/src/pipecat_flows/__init__.py
+++ b/src/pipecat_flows/__init__.py
@@ -3,56 +3,15 @@
 #
 # SPDX-License-Identifier: BSD 2-Clause License
 #
-"""Pipecat Flows.
+"""Pipecat Flows - Structured conversation framework for Pipecat.
 
 This package provides a framework for building structured conversations in Pipecat.
-The FlowManager can handle both static and dynamic conversation flows:
+The FlowManager can handle both static and dynamic conversation flows with support
+for state management, function calling, and cross-provider compatibility.
 
-1. Static Flows:
-   - Configuration-driven conversations with predefined paths
-   - Entire flow structure defined upfront
-   - Example:
-        from pipecat_flows import FlowArgs, FlowResult
-
-        async def collect_name(args: FlowArgs) -> FlowResult:
-            name = args["name"]
-            return {"status": "success", "name": name}
-
-        flow_config = {
-            "initial_node": "greeting",
-            "nodes": {
-                "greeting": {
-                    "messages": [...],
-                    "functions": [{
-                        "type": "function",
-                        "function": {
-                            "name": "collect_name",
-                            "handler": collect_name,
-                            "description": "...",
-                            "parameters": {...},
-                            "transition_to": "next_step"
-                        }
-                    }]
-                }
-            }
-        }
-        flow_manager = FlowManager(task, llm, flow_config=flow_config)
-
-2. Dynamic Flows:
-   - Runtime-determined conversations
-   - Nodes created or modified during execution
-   - Example:
-        from pipecat_flows import FlowArgs, FlowResult
-
-        async def collect_age(args: FlowArgs) -> FlowResult:
-            age = args["age"]
-            return {"status": "success", "age": age}
-
-        async def handle_transitions(function_name: str, args: Dict, flow_manager):
-            if function_name == "collect_age":
-                await flow_manager.set_node("next_step", create_next_node())
-
-        flow_manager = FlowManager(task, llm, transition_callback=handle_transitions)
+Static flows use predefined conversation paths configured upfront, while dynamic
+flows determine conversation structure at runtime. Both approaches support function
+calling, action execution, and seamless transitions between conversation states.
 """
 
 from .exceptions import (

--- a/src/pipecat_flows/actions.py
+++ b/src/pipecat_flows/actions.py
@@ -7,74 +7,76 @@
 """Action management system for conversation flows.
 
 This module provides the ActionManager class which handles execution of actions
-during conversation state transitions. It supports:
-- Built-in actions (TTS, conversation ending)
-- Custom action registration
-- Synchronous and asynchronous handlers
-- Pre and post-transition actions
-- Error handling and validation
+during conversation state transitions. It supports built-in actions, custom action
+registration, synchronous and asynchronous handlers, pre and post-transition actions,
+and comprehensive error handling and validation.
 
-Actions are used to perform side effects during conversations, such as:
-- Text-to-speech output
-- Database updates
-- External API calls
-- Custom integrations
+Actions are used to perform side effects during conversations, such as text-to-speech
+output, database updates, external API calls, and custom integrations.
 """
 
 import asyncio
 import inspect
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional
 
 from loguru import logger
 from pipecat.frames.frames import (
     BotStoppedSpeakingFrame,
     ControlFrame,
     EndFrame,
-    Frame,
     TTSSpeakFrame,
 )
-from pipecat.observers.base_observer import BaseObserver, FramePushed
-from pipecat.pipeline.task import PipelineTask, PipelineTaskSource
+from pipecat.pipeline.task import PipelineTask
 
-from .exceptions import ActionError
-from .types import ActionConfig, FlowActionHandler
+from pipecat_flows.exceptions import ActionError
+from pipecat_flows.types import ActionConfig, FlowActionHandler
+
+if TYPE_CHECKING:
+    from pipecat_flows.manager import FlowManager
 
 
 @dataclass
 class FunctionActionFrame(ControlFrame):
+    """Frame containing a function action to be executed.
+
+    Parameters:
+        action: Action configuration dictionary.
+        function: Function handler to execute.
+    """
+
     action: dict
     function: FlowActionHandler
 
 
 @dataclass
 class ActionFinishedFrame(ControlFrame):
+    """Frame indicating that an action has completed execution."""
+
     pass
 
 
 class ActionManager:
     """Manages the registration and execution of flow actions.
 
-    Actions are executed during state transitions and can include:
-    - Text-to-speech output
-    - Database updates
-    - External API calls
-    - Custom user-defined actions
+    Actions are executed during state transitions and can include text-to-speech
+    output, database updates, external API calls, and custom user-defined actions.
+    Supports both synchronous and asynchronous handlers with pre and post-transition
+    action execution.
 
     Built-in actions:
+
     - tts_say: Speak text using TTS
     - end_conversation: End the current conversation
-
-    Custom actions can be registered using register_action().
+    - function: Execute inline functions in the pipeline
     """
 
     def __init__(self, task: PipelineTask, flow_manager: "FlowManager"):
         """Initialize the action manager.
 
         Args:
-            task: PipelineTask instance used to queue frames
-            flow_manager: FlowManager instance that this ActionManager is part of
-            tts: Optional TTS service for voice actions
+            task: PipelineTask instance used to queue frames.
+            flow_manager: FlowManager instance that this ActionManager is part of.
         """
         self.action_handlers: Dict[str, Callable] = {}
         self.task = task
@@ -113,11 +115,11 @@ class ActionManager:
         """Register a handler for a specific action type.
 
         Args:
-            action_type: String identifier for the action (e.g., "tts_say")
-            handler: Async or sync function that handles the action
+            action_type: String identifier for the action (e.g., "tts_say").
+            handler: Async or sync function that handles the action.
 
         Raises:
-            ValueError: If handler is not callable
+            ValueError: If handler is not callable.
         """
         if not callable(handler):
             raise ValueError("Action handler must be callable")
@@ -128,13 +130,13 @@ class ActionManager:
         """Execute a list of actions.
 
         Args:
-            actions: List of action configurations to execute
+            actions: List of action configurations to execute.
 
         Raises:
-            ActionError: If action execution fails
+            ActionError: If action execution fails.
 
         Note:
-            Each action must have a 'type' field matching a registered handler
+            Each action must have a 'type' field matching a registered handler.
         """
         if not actions:
             return
@@ -207,10 +209,10 @@ class ActionManager:
         await self._maybe_wait_for_ongoing_actions_to_finish(previous_action_type, None)
 
     def schedule_deferred_post_actions(self, post_actions: List[ActionConfig]) -> None:
-        """Schedule "deferred" post-actions to be executed after next LLM completion.
+        """Schedule deferred post-actions to be executed after next LLM completion.
 
         Args:
-            post_actions: List of actions to execute
+            post_actions: List of actions to execute after LLM response.
         """
         self._deferred_post_actions = post_actions
 
@@ -228,14 +230,16 @@ class ActionManager:
     async def _maybe_wait_for_ongoing_actions_to_finish(
         self, previous_action_type: str, upcoming_action_type: Optional[str]
     ) -> None:
-        """Wait for ongoing actions to finish before executing the next action or moving on from
-        this set of actions, if needed.
+        """Wait for ongoing actions to finish before executing the next action if needed.
 
-        This method makes the determination of whether to wait based on the types of the previous
-        and upcoming actions.
+        This method determines whether to wait based on the types of the previous
+        and upcoming actions to avoid the upcoming action having an effect before
+        the previous one is done.
 
-        What it's trying to avoid is the upcoming action having an effect before the previous one is
-        done.
+        Args:
+            previous_action_type: Type of the previously executed action.
+            upcoming_action_type: Type of the next action to execute, or None if
+                this is the end of the action sequence.
         """
         needs_wait = False
         if previous_action_type == "tts_say":
@@ -279,7 +283,7 @@ class ActionManager:
         """Built-in handler for TTS actions.
 
         Args:
-            action: Action configuration containing 'text' to speak
+            action: Action configuration containing 'text' to speak.
         """
         text = action.get("text")
         if not text:
@@ -306,8 +310,8 @@ class ActionManager:
         includes a 'text' key, it will queue that text to be spoken before ending.
 
         Args:
-            action: Dictionary containing the action configuration.
-                Optional 'text' key for a goodbye message.
+            action: Action configuration dictionary. Optional 'text' key for a
+                goodbye message.
         """
         # Mark that we're starting the action
         self._increment_ongoing_actions_count()
@@ -321,14 +325,15 @@ class ActionManager:
         # EndFrame ensures that it'll never get delivered to our observer
 
     async def _handle_function_action(self, action: dict) -> None:
-        """Built-in handler for queuing functions to run "inline" in the pipeline (i.e. when the pipeline is done with all the work queued before it).
+        """Built-in handler for queuing functions to run inline in the pipeline.
 
-        This handler queues a FunctionFrame.
-        It expects a 'handler' key in the action, containing the function to execute.
+        This handler queues a FunctionActionFrame to be executed when the pipeline
+        is done with all the work queued before it. It expects a 'handler' key in
+        the action containing the function to execute.
 
         Args:
-            action: Dictionary containing the action configuration.
-                Required 'handler' key containing the function to execute.
+            action: Action configuration dictionary. Required 'handler' key
+                containing the function to execute.
         """
         handler = action.get("handler")
         if not handler:

--- a/src/pipecat_flows/actions.py
+++ b/src/pipecat_flows/actions.py
@@ -7,12 +7,20 @@
 """Action management system for conversation flows.
 
 This module provides the ActionManager class which handles execution of actions
-during conversation state transitions. It supports built-in actions, custom action
-registration, synchronous and asynchronous handlers, pre and post-transition actions,
-and comprehensive error handling and validation.
+during conversation state transitions. It supports:
 
-Actions are used to perform side effects during conversations, such as text-to-speech
-output, database updates, external API calls, and custom integrations.
+- Built-in actions (TTS, conversation ending)
+- Custom action registration
+- Synchronous and asynchronous handlers
+- Pre and post-transition actions
+- Error handling and validation
+
+Actions are used to perform side effects during conversations, such as:
+
+- Text-to-speech output
+- Database updates
+- External API calls
+- Custom integrations
 """
 
 import asyncio
@@ -59,16 +67,20 @@ class ActionFinishedFrame(ControlFrame):
 class ActionManager:
     """Manages the registration and execution of flow actions.
 
-    Actions are executed during state transitions and can include text-to-speech
-    output, database updates, external API calls, and custom user-defined actions.
-    Supports both synchronous and asynchronous handlers with pre and post-transition
-    action execution.
+    Actions are executed during state transitions and can include:
+
+    - Text-to-speech output
+    - Database updates
+    - External API calls
+    - Custom user-defined actions
 
     Built-in actions:
 
     - tts_say: Speak text using TTS
     - end_conversation: End the current conversation
     - function: Execute inline functions in the pipeline
+
+    Custom actions can be registered using register_action().
     """
 
     def __init__(self, task: PipelineTask, flow_manager: "FlowManager"):
@@ -209,7 +221,7 @@ class ActionManager:
         await self._maybe_wait_for_ongoing_actions_to_finish(previous_action_type, None)
 
     def schedule_deferred_post_actions(self, post_actions: List[ActionConfig]) -> None:
-        """Schedule deferred post-actions to be executed after next LLM completion.
+        """Schedule "deferred" post-actions to be executed after next LLM completion.
 
         Args:
             post_actions: List of actions to execute after LLM response.

--- a/src/pipecat_flows/adapters.py
+++ b/src/pipecat_flows/adapters.py
@@ -7,10 +7,15 @@
 """LLM provider adapters for normalizing function and message formats.
 
 This module provides adapters that normalize interactions between different
-LLM providers (OpenAI, Anthropic, Gemini, AWS Bedrock). It handles function
-name extraction, argument parsing, message content formatting, and
-provider-specific schema conversion to allow the flow manager to work
-consistently across providers.
+LLM providers (OpenAI, Anthropic, Gemini, AWS Bedrock). It handles:
+
+- Function name extraction
+- Argument parsing
+- Message content formatting
+- Provider-specific schema conversion
+
+The adapter system allows the flow manager to work with different LLM
+providers while maintaining a consistent internal format.
 """
 
 import sys

--- a/src/pipecat_flows/exceptions.py
+++ b/src/pipecat_flows/exceptions.py
@@ -6,43 +6,57 @@
 
 """Custom exceptions for the conversation flow system.
 
-This module defines the exception hierarchy used throughout the flow system:
-- FlowError: Base exception for all flow-related errors
-- FlowInitializationError: Initialization failures
-- FlowTransitionError: State transition issues
-- InvalidFunctionError: Function registration/calling problems
-- ActionError: Action execution failures
-
-These exceptions provide specific error types for better error handling
-and debugging.
+This module defines the exception hierarchy used throughout the flow system
+for better error handling and debugging. All exceptions inherit from FlowError
+to provide a common base for flow-related errors.
 """
 
 
 class FlowError(Exception):
-    """Base exception for all flow-related errors."""
+    """Base exception for all flow-related errors.
+
+    This is the parent class for all flow system exceptions. Use this
+    for generic flow errors or when a more specific exception doesn't apply.
+    """
 
     pass
 
 
 class FlowInitializationError(FlowError):
-    """Raised when flow initialization fails."""
+    """Raised when flow initialization fails.
+
+    This exception occurs during flow manager setup, typically due to
+    invalid configuration, missing dependencies, or initialization errors.
+    """
 
     pass
 
 
 class FlowTransitionError(FlowError):
-    """Raised when a state transition fails."""
+    """Raised when a state transition fails.
+
+    This exception occurs when transitioning between nodes fails due to
+    invalid node configurations, missing target nodes, or transition errors.
+    """
 
     pass
 
 
 class InvalidFunctionError(FlowError):
-    """Raised when an invalid or unavailable function is called."""
+    """Raised when an invalid or unavailable function is called.
+
+    This exception occurs when attempting to call functions that are not
+    properly registered, have invalid signatures, or cannot be found.
+    """
 
     pass
 
 
 class ActionError(FlowError):
-    """Raised when an action execution fails."""
+    """Raised when an action execution fails.
+
+    This exception occurs during action execution, including built-in actions
+    like TTS or custom actions, due to invalid configuration or execution errors.
+    """
 
     pass

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -7,12 +7,22 @@
 """Core conversation flow management system.
 
 This module provides the FlowManager class which orchestrates conversations
-across different LLM providers. It supports static flows with predefined paths,
-dynamic flows with runtime-determined transitions, state management and transitions,
-function registration and execution, action handling, and cross-provider compatibility.
+across different LLM providers. It supports:
 
-The flow manager coordinates all aspects of a conversation including LLM context
-management, function registration, state transitions, action execution, and error handling.
+- Static flows with predefined paths
+- Dynamic flows with runtime-determined transitions
+- State management and transitions
+- Function registration and execution
+- Action handling
+- Cross-provider compatibility
+
+The flow manager coordinates all aspects of a conversation, including:
+
+- LLM context management
+- Function registration
+- State transitions
+- Action execution
+- Error handling
 """
 
 import asyncio

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -168,6 +168,23 @@ class FlowManager:
 
         Raises:
             FlowInitializationError: If initialization fails.
+
+        Examples:
+            Static flow::
+
+                flow_manager = FlowManager(
+                    ... # Initialization parameters
+                )
+                # Static flow: no initialization args required
+                flow_manager.initialize()
+
+            Dynamic flow::
+
+                flow_manager = FlowManager(
+                    ... # Initialization parameters
+                )
+                # Dynamic flow: Initialize with the initial node configuration
+                flow_manager.initialize(create_initial_node())
         """
         if self.initialized:
             logger.warning(f"{self.__class__.__name__} already initialized")
@@ -520,6 +537,8 @@ class FlowManager:
 
     async def set_node_from_config(self, node_config: NodeConfig) -> None:
         """Set up a new conversation node and transition to it.
+
+        Used to manually transition between nodes in a dynamic flow.
 
         Args:
             node_config: Configuration for the new node.

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -379,7 +379,8 @@ class NodeConfig(NodeConfigRequired, total=False):
             "functions": [...],
             "pre_actions": [...],
             "post_actions": [...],
-            "context_strategy": ContextStrategyConfig(strategy=ContextStrategy.APPEND)
+            "context_strategy": ContextStrategyConfig(strategy=ContextStrategy.APPEND),
+            "respond_immediately": true,
         }
     """
 
@@ -406,6 +407,9 @@ def get_or_generate_node_name(node_config: NodeConfig) -> str:
 
 class FlowConfig(TypedDict):
     """Configuration for the entire conversation flow.
+
+    Note:
+        FlowConfig applies to static flows only.
 
     Parameters:
         initial_node: Name of the starting node.

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -6,10 +6,16 @@
 
 """Type definitions for the conversation flow system.
 
-This module defines the core types used throughout the flow system including
-function return types, argument types, node configurations, and flow configurations.
-These types provide structure and validation for flow configurations and function
-interactions across different LLM providers.
+This module defines the core types used throughout the flow system:
+
+- FlowResult: Function return type
+- FlowArgs: Function argument type
+- NodeConfig: Node configuration type
+- FlowConfig: Complete flow configuration type
+- FlowsFunctionSchema: A uniform schema for function calls in flows
+
+These types provide structure and validation for flow configurations
+and function interactions.
 """
 
 import uuid
@@ -292,9 +298,11 @@ class FlowsFunctionSchema:
 class FlowsDirectFunctionWrapper(BaseDirectFunctionWrapper):
     """Wrapper around a FlowsDirectFunction for metadata extraction and invocation.
 
-    Extracts metadata from the function signature and docstring, generates a
-    corresponding FunctionSchema, and provides function invocation capabilities
-    specifically for Flows direct functions.
+    The wrapper:
+
+    - extracts metadata from the function signature and docstring
+    - generates a corresponding FunctionSchema
+    - helps with function invocation
     """
 
     @classmethod

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -6,22 +6,17 @@
 
 """Type definitions for the conversation flow system.
 
-This module defines the core types used throughout the flow system:
-- FlowResult: Function return type
-- FlowArgs: Function argument type
-- NodeConfig: Node configuration type
-- FlowConfig: Complete flow configuration type
-
-These types provide structure and validation for flow configurations
-and function interactions.
+This module defines the core types used throughout the flow system including
+function return types, argument types, node configurations, and flow configurations.
+These types provide structure and validation for flow configurations and function
+interactions across different LLM providers.
 """
 
-import inspect
-import types
 import uuid
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -30,22 +25,19 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
-    Set,
     Tuple,
     TypedDict,
     TypeVar,
     Union,
-    get_args,
-    get_origin,
-    get_type_hints,
 )
 
-import docstring_parser
-from loguru import logger
 from pipecat.adapters.schemas.direct_function import BaseDirectFunctionWrapper
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 
 from pipecat_flows.exceptions import InvalidFunctionError
+
+if TYPE_CHECKING:
+    from pipecat_flows.manager import FlowManager
 
 T = TypeVar("T")
 TransitionHandler = Callable[[Dict[str, T], "FlowManager"], Awaitable[None]]
@@ -63,7 +55,12 @@ Returns:
 class FlowResult(TypedDict, total=False):
     """Base type for function results.
 
-    Example:
+    Parameters:
+        status: Status of the function execution.
+        error: Optional error message if execution failed.
+
+    Example::
+
         {
             "status": "success",
             "data": {"processed": True},
@@ -78,7 +75,8 @@ class FlowResult(TypedDict, total=False):
 FlowArgs = Dict[str, Any]
 """Type alias for function handler arguments.
 
-Example:
+Example::
+
     {
         "user_name": "John",
         "age": 25,
@@ -87,7 +85,8 @@ Example:
 """
 
 ConsolidatedFunctionResult = Tuple[Optional[FlowResult], Optional[Union["NodeConfig", str]]]
-"""
+"""Return type for "consolidated" functions.
+
 Return type for "consolidated" functions that do either or both of:
 - doing some work
 - specifying the next node to transition to after the work is done, specified as either:
@@ -99,10 +98,10 @@ LegacyFunctionHandler = Callable[[FlowArgs], Awaitable[FlowResult | Consolidated
 """Legacy function handler that only receives arguments.
 
 Args:
-    args: Dictionary of arguments from the function call
+    args: Dictionary of arguments from the function call.
 
 Returns:
-    FlowResult: Result of the function execution
+    FlowResult: Result of the function execution.
 """
 
 FlowFunctionHandler = Callable[
@@ -111,11 +110,11 @@ FlowFunctionHandler = Callable[
 """Modern function handler that receives both arguments and flow_manager.
 
 Args:
-    args: Dictionary of arguments from the function call
-    flow_manager: Reference to the FlowManager instance
+    args: Dictionary of arguments from the function call.
+    flow_manager: Reference to the FlowManager instance.
 
 Returns:
-    FlowResult: Result of the function execution
+    FlowResult: Result of the function execution.
 """
 
 
@@ -124,31 +123,37 @@ FunctionHandler = Union[LegacyFunctionHandler, FlowFunctionHandler]
 
 
 class FlowsDirectFunction(Protocol):
-    """
-    \"Direct\" function whose definition is automatically extracted from the function signature and docstring.
-    This can be used in NodeConfigs directly, in lieu of a FlowsFunctionSchema or function definition dict.
+    """Protocol for "direct" functions with automatic metadata extraction.
 
-    Args:
-        flow_manager: Reference to the FlowManager instance
-        **kwargs: Additional keyword arguments
-
-    Returns:
-        ConsolidatedFunctionResult: Result of the function execution, which can include both a
-            FlowResult and the next node to transition to.
+    "Direct" functions have their definition automatically extracted from the function
+    signature and docstring. This can be used in NodeConfigs directly, in lieu of a
+    FlowsFunctionSchema or function definition dict.
     """
 
     def __call__(
         self, flow_manager: "FlowManager", **kwargs: Any
-    ) -> Awaitable[ConsolidatedFunctionResult]: ...
+    ) -> Awaitable[ConsolidatedFunctionResult]:
+        """Execute the direct function.
+
+        Args:
+            flow_manager: Reference to the FlowManager instance.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            Result of the function execution, which can include both a FlowResult
+            and the next node to transition to.
+        """
+        ...
 
 
 LegacyActionHandler = Callable[[Dict[str, Any]], Awaitable[None]]
 """Legacy action handler type that only receives the action dictionary.
 
 Args:
-    action: Dictionary containing action configuration and parameters
+    action: Dictionary containing action configuration and parameters.
 
-Example:
+Example::
+
     async def simple_handler(action: dict):
         await notify(action["text"])
 """
@@ -157,17 +162,22 @@ FlowActionHandler = Callable[[Dict[str, Any], "FlowManager"], Awaitable[None]]
 """Modern action handler type that receives both action and flow_manager.
 
 Args:
-    action: Dictionary containing action configuration and parameters
-    flow_manager: Reference to the FlowManager instance
+    action: Dictionary containing action configuration and parameters.
+    flow_manager: Reference to the FlowManager instance.
 
-Example:
+Example::
+
     async def advanced_handler(action: dict, flow_manager: FlowManager):
         await flow_manager.transport.notify(action["text"])
 """
 
 
 class ActionConfigRequired(TypedDict):
-    """Required fields for action configuration."""
+    """Required fields for action configuration.
+
+    Parameters:
+        type: Action type identifier.
+    """
 
     type: str
 
@@ -175,13 +185,13 @@ class ActionConfigRequired(TypedDict):
 class ActionConfig(ActionConfigRequired, total=False):
     """Configuration for an action.
 
-    Required:
-        type: Action type identifier (e.g. "tts_say", "notify_slack")
+    Parameters:
+        type: Action type identifier (e.g. "tts_say", "notify_slack").
+        handler: Callable to handle the action.
+        text: Text for tts_say action.
 
-    Optional:
-        handler: Callable to handle the action
-        text: Text for tts_say action
-        Additional fields are allowed and passed to the handler
+    Note:
+        Additional fields are allowed and passed to the handler.
     """
 
     handler: Union[LegacyActionHandler, FlowActionHandler]
@@ -191,10 +201,10 @@ class ActionConfig(ActionConfigRequired, total=False):
 class ContextStrategy(Enum):
     """Strategy for managing context during node transitions.
 
-    Attributes:
-        APPEND: Append new messages to existing context (default)
-        RESET: Reset context with new messages only
-        RESET_WITH_SUMMARY: Reset context but include an LLM-generated summary
+    Parameters:
+        APPEND: Append new messages to existing context (default).
+        RESET: Reset context with new messages only.
+        RESET_WITH_SUMMARY: Reset context but include an LLM-generated summary.
     """
 
     APPEND = "append"
@@ -206,16 +216,20 @@ class ContextStrategy(Enum):
 class ContextStrategyConfig:
     """Configuration for context management.
 
-    Attributes:
-        strategy: Strategy to use for context management
-        summary_prompt: Required prompt text when using RESET_WITH_SUMMARY
+    Parameters:
+        strategy: Strategy to use for context management.
+        summary_prompt: Required prompt text when using RESET_WITH_SUMMARY.
     """
 
     strategy: ContextStrategy
     summary_prompt: Optional[str] = None
 
     def __post_init__(self):
-        """Validate configuration."""
+        """Validate configuration.
+
+        Raises:
+            ValueError: If summary_prompt is missing when using RESET_WITH_SUMMARY.
+        """
         if self.strategy == ContextStrategy.RESET_WITH_SUMMARY and not self.summary_prompt:
             raise ValueError("summary_prompt is required when using RESET_WITH_SUMMARY strategy")
 
@@ -224,22 +238,24 @@ class ContextStrategyConfig:
 class FlowsFunctionSchema:
     """Function schema with Flows-specific properties.
 
-    This class provides similar functionality to FunctionSchema with additional
-    fields for Pipecat Flows integration.
+    This class extends standard function schemas with additional fields for
+    Pipecat Flows integration including handler assignment and transition logic.
 
-    Attributes:
-        name: Name of the function
-        description: Description of the function
-        properties: Dictionary defining properties types and descriptions
-        required: List of required parameters
-        handler: Function handler to process the function call
-        transition_to: Target node to transition to after function execution (deprecated)
-        transition_callback: Callback function for dynamic transitions (deprecated)
+    Parameters:
+        name: Name of the function.
+        description: Description of the function.
+        properties: Dictionary defining parameter types and descriptions.
+        required: List of required parameter names.
+        handler: Function handler to process the function call.
+        transition_to: Target node to transition to after function execution.
 
-    Deprecated:
-        0.0.18: `transition_to` and `transition_callback` are deprecated and will be removed in a
-            future version. Use a "consolidated" `handler` that returns a tuple (result, next_node)
-            instead.
+            .. deprecated:: 0.0.18
+                Use a "consolidated" handler that returns a tuple (result, next_node) instead.
+
+        transition_callback: Callback function for dynamic transitions.
+
+            .. deprecated:: 0.0.18
+                Use a "consolidated" handler that returns a tuple (result, next_node) instead.
     """
 
     name: str
@@ -251,7 +267,11 @@ class FlowsFunctionSchema:
     transition_callback: Optional[Callable] = None
 
     def __post_init__(self):
-        """Validate the schema configuration."""
+        """Validate the schema configuration.
+
+        Raises:
+            ValueError: If both transition_to and transition_callback are specified.
+        """
         if self.transition_to and self.transition_callback:
             raise ValueError("Cannot specify both transition_to and transition_callback")
 
@@ -259,7 +279,7 @@ class FlowsFunctionSchema:
         """Convert to a standard FunctionSchema for use with LLMs.
 
         Returns:
-            FunctionSchema without flow-specific fields
+            FunctionSchema without flow-specific fields.
         """
         return FunctionSchema(
             name=self.name,
@@ -270,30 +290,56 @@ class FlowsFunctionSchema:
 
 
 class FlowsDirectFunctionWrapper(BaseDirectFunctionWrapper):
-    """
-    Wrapper around a FlowsDirectFunction that:
-    - extracts metadata from the function signature and docstring
-    - generates a corresponding FunctionSchema
-    - helps with function invocation
+    """Wrapper around a FlowsDirectFunction for metadata extraction and invocation.
+
+    Extracts metadata from the function signature and docstring, generates a
+    corresponding FunctionSchema, and provides function invocation capabilities
+    specifically for Flows direct functions.
     """
 
     @classmethod
     def special_first_param_name(cls) -> str:
+        """Get the special first parameter name for Flows direct functions.
+
+        Returns:
+            The string "flow_manager" which is expected as the first parameter.
+        """
         return "flow_manager"
 
     @classmethod
     def validate_function(cls, function: Callable) -> None:
+        """Validate the function signature and docstring.
+
+        Args:
+            function: The function to validate.
+
+        Raises:
+            InvalidFunctionError: If the function does not meet the requirements.
+        """
         try:
             super().validate_function(function)
         except Exception as e:
             raise InvalidFunctionError(str(e)) from e
 
     async def invoke(self, args: Mapping[str, Any], flow_manager: "FlowManager"):
+        """Invoke the wrapped function with the provided arguments.
+
+        Args:
+            args: Arguments to pass to the function.
+            flow_manager: FlowManager instance for function execution context.
+
+        Returns:
+            The result of the function call.
+        """
         return await self.function(flow_manager=flow_manager, **args)
 
 
 class NodeConfigRequired(TypedDict):
-    """Required fields for node configuration."""
+    """Required fields for node configuration.
+
+    Parameters:
+        task_messages: List of message dicts defining the current node's objectives.
+    """
 
     task_messages: List[dict]
 
@@ -301,21 +347,22 @@ class NodeConfigRequired(TypedDict):
 class NodeConfig(NodeConfigRequired, total=False):
     """Configuration for a single node in the flow.
 
-    Required fields:
-        task_messages: List of message dicts defining the current node's objectives
+    Parameters:
+        task_messages: List of message dicts defining the current node's objectives.
+        name: Name of the node, useful for debug logging when returning a next node
+            from a "consolidated" function.
+        role_messages: List of message dicts defining the bot's role/personality.
+        functions: List of function definitions in provider-specific format,
+            FunctionSchema, or FlowsFunctionSchema; or a "direct function" whose
+            definition is automatically extracted.
+        pre_actions: Actions to execute before LLM inference.
+        post_actions: Actions to execute after LLM inference.
+        context_strategy: Strategy for updating context during transitions.
+        respond_immediately: Whether to run LLM inference as soon as the node is
+            set (default: True).
 
-    Optional fields:
-        name: Name of the node, useful for debug logging when returning a next node from a
-            "consolidated" function
-        role_messages: List of message dicts defining the bot's role/personality
-        functions: List of function definitions in provider-specific format, FunctionSchema,
-            or FlowsFunctionSchema; or a "direct function" whose definition is automatically extracted
-        pre_actions: Actions to execute before LLM inference
-        post_actions: Actions to execute after LLM inference
-        context_strategy: Strategy for updating context during transitions
-        respond_immediately: Whether to run LLM inference as soon as the node is set (default: True)
+    Example::
 
-    Example:
         {
             "role_messages": [
                 {
@@ -346,18 +393,26 @@ class NodeConfig(NodeConfigRequired, total=False):
 
 
 def get_or_generate_node_name(node_config: NodeConfig) -> str:
-    """Get the node name from the given configuration, defaulting to a UUID if not set."""
+    """Get the node name from configuration or generate a UUID if not set.
+
+    Args:
+        node_config: Node configuration dictionary.
+
+    Returns:
+        Node name from config or generated UUID string.
+    """
     return node_config.get("name", str(uuid.uuid4()))
 
 
 class FlowConfig(TypedDict):
     """Configuration for the entire conversation flow.
 
-    Attributes:
-        initial_node: Name of the starting node
-        nodes: Dictionary mapping node names to their configurations
+    Parameters:
+        initial_node: Name of the starting node.
+        nodes: Dictionary mapping node names to their configurations.
 
-    Example:
+    Example::
+
         {
             "initial_node": "greeting",
             "nodes": {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,0 @@
-pytest~=8.3.2
-pytest-asyncio~=0.23.5
-pytest-cov~=4.1.0


### PR DESCRIPTION
The goals of this PR are to:
- Add auto-generated reference docs, hosted on ReadTheDocs
- Reinforce good docs auto-generation by adding linting checks to CI
- Add a pre-commit.sh to detect linting issues locally
- Update pyproject.toml with linting rules in support of above and IDEs to help flag linting issues
- Consolidate test and dev requirements into dev-requirements.txt
- Update CONTRIBUTING.md with the docstrings guidance (same contributing from Pipecat)
- Update local hacking steps to include a pre-commit hook to help detect linting errors when pushing commits