### PR TITLE
Update .pre-commit-config.yaml to use pyproject.toml linting rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,5 +4,5 @@ repos:
     hooks:
       - id: ruff
         language_version: python3
-        args: [--select, D, I]
+        args: [--fix]
       - id: ruff-format


### PR DESCRIPTION
`--select` overrides the project's rules. We'll switch to `--fix` to use the pyproject.toml rules.