### PR TITLE
Add switch_llm function to manager for runtime model switching

### DIFF
--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -155,6 +155,21 @@ class FlowManager:
         self._showed_deprecation_warning_for_transition_fields = False
         self._showed_deprecation_warning_for_set_node = False
 
+    def switch_llm(self, llm: LLMService, context_aggregator: Any) -> None:
+        """Switch to another llm and reset tools and nodes but keep state.
+        
+        Args:
+            llm : LLM service instance (e.g., OpenAI, Anthropic)
+            context_aggregator: Context aggregator for updating user context 
+        """
+        self.llm = llm
+        self._context_aggregator = context_aggregator
+        self.action_manager = ActionManager(self.task, flow_manager=self)
+        self.adapter = create_adapter(llm)
+        self._pending_function_calls = 0
+        self.current_functions: Set[str] = set()  # Track registered functions
+        self.current_node: Optional[str] = None
+
     def _validate_transition_callback(self, name: str, callback: Any) -> None:
         """Validate a transition callback.
 


### PR DESCRIPTION
### Description

This PR adds a `switch_llm` function to the manager that allows changing the model during execution.

### Changes

- Added `switch_llm()` function in the manager
- The function resets tools and nodes but preserves state
- Enables runtime model switching without losing conversation context

### Known Issue

However, there's a persistent problem:

When `TextFrame` objects are received by `LLMUserContextAggregator` or `LLMAssistantContextAggregator`, a loop is created and text gets added multiple times to the context. 

**Example:**
- Input: `Hello my name is joe.`
- Context records: `Hello Hello my Hello my name Hello Hello Hello my name is`

### Help Needed

If someone could help me progress on this issue, I would appreciate it. I've tried adding logs everywhere in the Aggregators but I still don't understand where this is coming from.

### Testing

- [x] Basic functionality works
- [x] State preservation confirmed
- [x] Tools and nodes reset correctly
- [ ] Text duplication issue needs investigation

---

**Note:** This PR is functional but the text duplication issue in the context aggregators needs to be resolved before merging.