### PR TITLE
[DO NOT MERGE YET] Gemini doesn't really support "system" messages inline in conversatio…

### DIFF
--- a/examples/dynamic/insurance_gemini.py
+++ b/examples/dynamic/insurance_gemini.py
@@ -188,7 +188,7 @@ def create_initial_node() -> NodeConfig:
         ],
         "task_messages": [
             {
-                "role": "system",
+                "role": "user",
                 "content": "Start by asking for the customer's age.",
             }
         ],
@@ -210,7 +210,7 @@ def create_marital_status_node() -> NodeConfig:
         "name": "marital_status",
         "task_messages": [
             {
-                "role": "system",
+                "role": "user",
                 "content": (
                     "Ask about the customer's marital status (single or married). "
                     "Wait for their response before calling collect_marital_status. "
@@ -238,7 +238,7 @@ def create_quote_calculation_node(age: int, marital_status: str) -> NodeConfig:
         "name": "quote_calculation",
         "task_messages": [
             {
-                "role": "system",
+                "role": "user",
                 "content": (
                     f"Calculate a quote for {age} year old {marital_status} customer. "
                     "Call calculate_quote with their information. "
@@ -269,7 +269,7 @@ def create_quote_results_node(
         "name": "quote_results",
         "task_messages": [
             {
-                "role": "system",
+                "role": "user",
                 "content": (
                     f"Quote details:\n"
                     f"Monthly Premium: ${quote['monthly_premium']:.2f}\n"
@@ -311,7 +311,7 @@ def create_end_node() -> NodeConfig:
         "name": "end",
         "task_messages": [
             {
-                "role": "system",
+                "role": "user",
                 "content": (
                     "Thank the customer for their time and end the conversation. "
                     "Mention that a representative will contact them about the quote."

--- a/examples/static/movie_explorer_gemini.py
+++ b/examples/static/movie_explorer_gemini.py
@@ -373,7 +373,7 @@ flow_config: FlowConfig = {
         "explore_movie": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": """Help the user learn more about movies. You can:
 - Use get_movie_details when they express interest in a specific movie
 - Use get_similar_movies to show recommendations
@@ -436,7 +436,7 @@ After showing details or recommendations, ask if they'd like to explore another 
         "end": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "Thank the user warmly and mention they can return anytime to discover more movies.",
                 }
             ],

--- a/examples/static/patient_intake_gemini.py
+++ b/examples/static/patient_intake_gemini.py
@@ -198,7 +198,7 @@ flow_config: FlowConfig = {
             ],
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "Start by introducing yourself to Chad Bailey, then ask for their date of birth, including the year. Once they provide their birthday, use verify_birthday to check it. If verified (1983-01-01), proceed to prescriptions.",
                 }
             ],
@@ -227,7 +227,7 @@ flow_config: FlowConfig = {
         "get_prescriptions": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "This step is for collecting prescriptions. Ask them what prescriptions they're taking, including the dosage. After recording prescriptions (or confirming none), proceed to allergies.",
                 }
             ],
@@ -270,7 +270,7 @@ flow_config: FlowConfig = {
         "get_allergies": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "Collect allergy information. Ask about any allergies they have. After recording allergies (or confirming none), proceed to medical conditions.",
                 }
             ],
@@ -308,7 +308,7 @@ flow_config: FlowConfig = {
         "get_conditions": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "Collect medical condition information. Ask about any medical conditions they have. After recording conditions (or confirming none), proceed to visit reasons.",
                 }
             ],
@@ -346,7 +346,7 @@ flow_config: FlowConfig = {
         "get_visit_reasons": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "Collect information about the reason for their visit. Ask what brings them to the doctor today. After recording their reasons, proceed to verification.",
                 }
             ],
@@ -384,7 +384,7 @@ flow_config: FlowConfig = {
         "verify": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": """Review all collected information with the patient. Follow these steps:
 1. Summarize their prescriptions, allergies, conditions, and visit reasons
 2. Ask if everything is correct
@@ -423,7 +423,7 @@ Be thorough in reviewing all details and wait for explicit confirmation.""",
         "confirm": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "Once confirmed, thank them, then use the complete_intake function to end the conversation.",
                 }
             ],
@@ -443,7 +443,7 @@ Be thorough in reviewing all details and wait for explicit confirmation.""",
         "end": {
             "task_messages": [
                 {
-                    "role": "system",
+                    "role": "user",
                     "content": "Thank them for their time and end the conversation.",
                 }
             ],


### PR DESCRIPTION
…n history. So, let's match what we do for Anthropic and AWS and make `task_messages` use "user" messages.

The problem is that the Pipecat `GoogleLLMContext`, the last "system" message in the list "wins" and becomes _the_ system message, overwriting the previous one. We were seeing the `role_messages` message getting "overwritten" by the `task_messages` message.

This represents the immediate-term fix for https://github.com/pipecat-ai/pipecat-flows/issues/127. In an upcoming PR, I intend to implement some safeguards to make the system a bit more robust against this kind of misconfiguration.

**NOTE: this PR depends on [an upcoming Pipecat fix](https://github.com/pipecat-ai/pipecat/pull/2214) to work properly. Pipecat is injecting system instructions as "user" messages in conversation history in some cases it's not meant to. If we merged this PR without first waiting for the Pipecat fix, we'd see the `role_messages` message appearing later in the conversation history than the `task_messages` message, causing the bot to respond directly to the `role_messages` message rather than the more immediate prompt.**