### PR TITLE
Add Workaround for Mistral Tool Message Handling

### DIFF
--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -903,6 +903,16 @@ In all of these cases, you can provide a `name` in your new node's config for de
         try:
             messages = []
 
+            # Add an empty assistant message if the last message has a role "tool".
+            # This is a workaround for Mistral, which requires an assistant message following a tool message.
+            if (
+                len(self._context_aggregator.user()._context.messages) > 0
+                and self._context_aggregator.user()._context.messages[-1].get("role") == "tool"
+            ):
+                messages.append(
+                    {"role": "assistant", "content": " "}
+                )  # Keep the space in the content; an empty string does not work.
+
             # Add role messages if provided.
             # Note that these come before any possible summary message; some
             # LLMs only support a single system instruction, and the first role


### PR DESCRIPTION
This code snippet is designed to manage the flow of messages in a conversation context. It initializes an empty list called `messages`. The purpose of the subsequent logic is to add an empty assistant message if the last message in the user's context has the role of "tool." This is a workaround specifically for Mistral, which requires an assistant message to follow any tool message.

The condition checks if there are any messages in the user's context. If there are, it verifies whether the last message's role is "tool." If both conditions are met, it appends a new message to the `messages` list with the role of "assistant" and a single space as the content. This space is crucial because an empty string does not function as intended.

This code has been added to `manager.py` to facilitate the transition from one node to another after a tool has been called by the language model (LLM).