### PR TITLE
Fix warm transfer example AttributeError

### DIFF
--- a/examples/dynamic/warm_transfer.py
+++ b/examples/dynamic/warm_transfer.py
@@ -165,8 +165,8 @@ async def mute_customer(action: dict, flow_manager: FlowManager):
 
 
 async def start_hold_music(action: dict, flow_manager: FlowManager):
-    hold_music_args = flow_manager.state["hold_music_args"]
-    flow_manager.state["hold_music_process"] = await asyncio.create_subprocess_exec(
+    hold_music_args = flow_manager._state["hold_music_args"]
+    flow_manager._state["hold_music_process"] = await asyncio.create_subprocess_exec(
         sys.executable,
         str(hold_music_args["script_path"]),
         "-m",
@@ -198,7 +198,7 @@ async def make_customer_hear_only_hold_music(action: dict, flow_manager: FlowMan
 
 async def print_human_agent_join_url(action: dict, flow_manager: FlowManager):
     """Print the URL for joining as a human agent."""
-    logger.info(f"\n\nJOIN AS AGENT:\n{flow_manager.state['human_agent_join_url']}\n")
+    logger.info(f"\n\nJOIN AS AGENT:\n{flow_manager._state['human_agent_join_url']}\n")
 
 
 async def unmute_customer_and_make_humans_hear_each_other(action: dict, flow_manager: FlowManager):
@@ -666,12 +666,12 @@ async def main():
         logger.info(
             f"\n\nJOIN AS CUSTOMER:\n{room_url}{'?' if '?' not in room_url else '&'}t={customer_token}\n"
         )
-        flow_manager.state["human_agent_join_url"] = (
+        flow_manager._state["human_agent_join_url"] = (
             f"{room_url}{'?' if '?' not in room_url else '&'}t={human_agent_token}"
         )
 
         # Prepare hold music args
-        flow_manager.state["hold_music_args"] = {
+        flow_manager._state["hold_music_args"] = {
             "script_path": Path(__file__).parent.parent / "assets" / "hold_music" / "hold_music.py",
             "wav_file_path": Path(__file__).parent.parent
             / "assets"
@@ -685,7 +685,7 @@ async def main():
 
         # Clean up hold music process at exit, if needed
         def cleanup_hold_music_process():
-            hold_music_process = flow_manager.state.get("hold_music_process")
+            hold_music_process = flow_manager._state.get("hold_music_process")
             if hold_music_process:
                 try:
                     hold_music_process.terminate()

--- a/examples/dynamic/warm_transfer.py
+++ b/examples/dynamic/warm_transfer.py
@@ -40,7 +40,7 @@ import atexit
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import aiohttp
 from dotenv import load_dotenv
@@ -149,7 +149,7 @@ async def mute_customer(action: dict, flow_manager: FlowManager):
 
     Do it by revoking their canSnd permission, which both mutes them and ensures that they can't unmute.
     """
-    transport: DailyTransport = flow_manager.transport
+    transport = cast(DailyTransport, flow_manager._transport)
     customer_participant_id = get_customer_participant_id(transport=transport)
 
     if customer_participant_id:
@@ -183,7 +183,7 @@ async def make_customer_hear_only_hold_music(action: dict, flow_manager: FlowMan
 
     We don't want them hearing the bot and the human agent talking.
     """
-    transport: DailyTransport = flow_manager.transport
+    transport = cast(DailyTransport, flow_manager._transport)
     customer_participant_id = get_customer_participant_id(transport=transport)
 
     if customer_participant_id:
@@ -203,7 +203,7 @@ async def print_human_agent_join_url(action: dict, flow_manager: FlowManager):
 
 async def unmute_customer_and_make_humans_hear_each_other(action: dict, flow_manager: FlowManager):
     """Unmute the customer and make it so the customer and human agent can hear each other."""
-    transport: DailyTransport = flow_manager.transport
+    transport = cast(DailyTransport, flow_manager._transport)
     customer_participant_id = get_customer_participant_id(transport=transport)
     agent_participant_id = get_human_agent_participant_id(transport=transport)
 
@@ -632,7 +632,7 @@ async def main():
             - Otherwise...nothing, for the purposes of this demo. We're assuming the human agent won't join while the conversation flow is any other node.
             """
             user_id = participant.get("info", {}).get("userId")
-            if user_id == "agent" and flow_manager.current_node == "transferring_to_human_agent":
+            if user_id == "agent" and flow_manager._current_node == "transferring_to_human_agent":
                 await start_human_agent_interaction(flow_manager=flow_manager)
 
         @transport.event_handler("on_participant_left")


### PR DESCRIPTION
## Description
Fixes the `AttributeError: 'FlowManager' object has no attribute 'state'` error in the warm transfer example.

## Changes
- Updated all references from `flow_manager.state` to `flow_manager._state` in `examples/dynamic/warm_transfer.py`
- The FlowManager class had changed its `state` attribute to `_state` (with underscore prefix) but the example code was still using the old attribute name

## Fixed Locations
- `start_hold_music` function (2 occurrences)
- `print_human_agent_join_url` function (1 occurrence)
- Main function setup (2 occurrences)  
- Cleanup function (1 occurrence)

## Testing
- ✅ Script now runs without errors
- ✅ Warm transfer functionality works correctly

## Fixes
Resolves the runtime error that prevented the warm transfer example from executing.