### PR TITLE
Add dynamic versioning via setuptools_scm

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -3,44 +3,31 @@ name: Publish to PyPI
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to publish (must match pyproject.toml, e.g. 0.0.4)'
-        required: true
+      gitref:
         type: string
+        description: 'what git tag to build (e.g. v0.0.22)'
+        required: true
 
 jobs:
   build:
     name: 'Build and upload wheels'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          fetch-tags: true
-          fetch-depth: 100
+          ref: ${{ github.event.inputs.gitref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
           version: 'latest'
-
       - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Verify version matches
-        run: |
-          PROJECT_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          if [ "$PROJECT_VERSION" != "${{ github.event.inputs.version }}" ]; then
-            echo "Error: Input version (${{ github.event.inputs.version }}) does not match pyproject.toml version ($PROJECT_VERSION)"
-            exit 1
-          fi
-
+        run: uv python install 3.10
       - name: Install development dependencies
         run: uv sync --group dev
-
       - name: Build project
         run: uv build
-
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -56,29 +43,36 @@ jobs:
       url: https://pypi.org/p/pipecat-ai-flows
     permissions:
       id-token: write
-      contents: write # Needed for tagging
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-tags: true
-          fetch-depth: 100
-
-      - name: Create release tag
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git tag -a "v${{ github.event.inputs.version }}" -m "Version ${{ github.event.inputs.version }}"
-          git push origin "v${{ github.event.inputs.version }}"
-
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:
           name: wheels
           path: ./dist
-
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
           print-hash: true
+
+  publish-to-test-pypi:
+    name: 'Publish to Test PyPI'
+    runs-on: ubuntu-latest
+    needs: [build]
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pipecat-ai-flows
+    permissions:
+      id-token: write
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels
+          path: ./dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,46 +1,27 @@
 name: Publish to TestPyPI
 
-on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (must match pyproject.toml, e.g. 0.0.4)'
-        required: true
-        type: string
+on: workflow_dispatch
 
 jobs:
   build:
     name: 'Build and upload wheels'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-tags: true
           fetch-depth: 100
-
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
           version: 'latest'
-
       - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Verify version matches
-        run: |
-          PROJECT_VERSION=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
-          if [ "$PROJECT_VERSION" != "${{ github.event.inputs.version }}" ]; then
-            echo "Error: Input version (${{ github.event.inputs.version }}) does not match pyproject.toml version ($PROJECT_VERSION)"
-            exit 1
-          fi
-
+        run: uv python install 3.10
       - name: Install development dependencies
         run: uv sync --group dev
-
       - name: Build project
         run: uv build
-
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -62,10 +43,9 @@ jobs:
         with:
           name: wheels
           path: ./dist
-
-      - name: Publish to TestPyPI
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
           verbose: true
           print-hash: true
+          repository-url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pipecat-ai-flows"
-version = "0.0.21"
+dynamic = ["version"]
 description = "Conversation Flow management for Pipecat AI applications"
 license = { text = "BSD 2-Clause License" }
 readme = "README.md"
@@ -40,6 +40,7 @@ dev = [
     "pytest-cov~=4.1.0",
     "ruff~=0.12.1",
     "setuptools~=78.1.1",
+    "setuptools_scm~=8.3.1",
     "python-dotenv>=1.0.1,<2.0.0",
     "pipecat-ai[webrtc,daily,silero,deepgram,openai,cartesia,runner,anthropic,google,aws]>=0.0.79",
 ]
@@ -78,3 +79,7 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"
+fallback_version = "0.0.0-dev"

--- a/uv.lock
+++ b/uv.lock
@@ -930,7 +930,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1458,7 +1458,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.13'" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [
@@ -2329,7 +2329,6 @@ webrtc = [
 
 [[package]]
 name = "pipecat-ai-flows"
-version = "0.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -2351,6 +2350,7 @@ dev = [
     { name = "python-dotenv" },
     { name = "ruff" },
     { name = "setuptools" },
+    { name = "setuptools-scm" },
 ]
 docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2383,6 +2383,7 @@ dev = [
     { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
     { name = "ruff", specifier = "~=0.12.1" },
     { name = "setuptools", specifier = "~=78.1.1" },
+    { name = "setuptools-scm", specifier = "~=8.3.1" },
 ]
 docs = [
     { name = "sphinx", specifier = ">=8.1.3" },
@@ -3405,6 +3406,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/9c/42314ee079a3e9c24b27515f9fbc7a3c1d29992c33451779011c74488375/setuptools-78.1.1.tar.gz", hash = "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d", size = 1368163, upload-time = "2025-04-19T18:23:36.68Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl", hash = "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561", size = 1256462, upload-time = "2025-04-19T18:23:34.525Z" },
+]
+
+[[package]]
+name = "setuptools-scm"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/19/7ae64b70b2429c48c3a7a4ed36f50f94687d3bfcd0ae2f152367b6410dff/setuptools_scm-8.3.1.tar.gz", hash = "sha256:3d555e92b75dacd037d32bafdf94f97af51ea29ae8c7b234cf94b7a5bd242a63", size = 78088, upload-time = "2025-04-23T11:53:19.739Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/ac/8f96ba9b4cfe3e4ea201f23f4f97165862395e9331a424ed325ae37024a8/setuptools_scm-8.3.1-py3-none-any.whl", hash = "sha256:332ca0d43791b818b841213e76b1971b7711a960761c5bea5fc5cdb5196fbce3", size = 43935, upload-time = "2025-04-23T11:53:17.922Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This follows the pattern from pipecat-ai. This will ensure that versions are marked as X.Y.Z.devN (e.g. 0.0.22.dev0) between releases.

setuptools-scm uses the git tags and commits to set these versions automatically.

Also, update github workflows for publishing to PyPI. This now aligns with pipecat-ai.