### PR TITLE
Properly silencing deprecation warnings for transitions after first log

### DIFF
--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -1062,9 +1062,8 @@ In all of these cases, you can provide a `name` in your new node's config for de
 
             # Warn about usage of deprecated transition_to and transition_callback
             if (
-                (has_transition_to or has_transition_callback)
-                and not self._showed_deprecation_warning_for_transition_fields
-            ):
+                has_transition_to or has_transition_callback
+            ) and not self._showed_deprecation_warning_for_transition_fields:
                 self._showed_deprecation_warning_for_transition_fields = True
                 with warnings.catch_warnings():
                     warnings.simplefilter("always")


### PR DESCRIPTION
The logic to only show the transition deprecation warning wasn't correct, which caused the warning to spam.  Parentheses are required.