### PR TITLE
Deprecate RESET_WITH_SUMMARY in favor of native Pipecat summarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `RESET_WITH_SUMMARY` context strategy is deprecated in favor of Pipecat's
   native context summarization. A `DeprecationWarning` is now emitted at runtime
-  when the strategy is used. See
+  when the strategy is used. To trigger on-demand summarization during a node
+  transition, push an `LLMSummarizeContextFrame` in a pre-action. See
   https://docs.pipecat.ai/guides/fundamentals/context-summarization for the
-  recommended approach. Will be removed in a future version.
+  full guide. Will be removed in a future version.
 
 ## [0.0.24] - 2026-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped dependency versions for security updates: `loguru`, `docstring_parser`,
   `build`, `pip-tools`, `pre-commit`, `pyright`, `pytest-asyncio`, and `ruff`.
 
+### Deprecated
+
+- `RESET_WITH_SUMMARY` context strategy is deprecated in favor of Pipecat's
+  native context summarization. A `DeprecationWarning` is now emitted at runtime
+  when the strategy is used. See
+  https://docs.pipecat.ai/guides/fundamentals/context-summarization for the
+  recommended approach. Will be removed in a future version.
+
 ## [0.0.24] - 2026-03-20
 
 ### Added

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -981,7 +981,9 @@ In all of these cases, you can provide a `name` in your new node's config for de
                     self._showed_deprecation_warning_for_reset_with_summary = True
                     warnings.warn(
                         "RESET_WITH_SUMMARY is deprecated and will be removed in a future version. "
-                        "Use Pipecat's native context summarization instead. See "
+                        "Use Pipecat's native context summarization instead. To trigger "
+                        "on-demand summarization during a node transition, push an "
+                        "LLMSummarizeContextFrame in a pre-action. See "
                         "https://docs.pipecat.ai/guides/fundamentals/context-summarization",
                         DeprecationWarning,
                         stacklevel=2,

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -178,6 +178,7 @@ class FlowManager:
         self._showed_deprecation_warning_for_transition_fields = False
         self._showed_deprecation_warning_for_set_node = False
         self._showed_deprecation_warning_for_role_messages = False
+        self._showed_deprecation_warning_for_reset_with_summary = False
 
     @property
     def state(self) -> Dict[str, Any]:
@@ -974,6 +975,17 @@ In all of these cases, you can provide a `name` in your new node's config for de
                 messages.extend(role_messages)
 
             update_config = strategy or self._context_strategy
+
+            if update_config.strategy == ContextStrategy.RESET_WITH_SUMMARY:
+                if not self._showed_deprecation_warning_for_reset_with_summary:
+                    self._showed_deprecation_warning_for_reset_with_summary = True
+                    warnings.warn(
+                        "RESET_WITH_SUMMARY is deprecated and will be removed in a future version. "
+                        "Use Pipecat's native context summarization instead. See "
+                        "https://docs.pipecat.ai/guides/fundamentals/context-summarization",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
 
             if (
                 update_config.strategy == ContextStrategy.RESET_WITH_SUMMARY

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -213,7 +213,9 @@ class ContextStrategy(Enum):
         RESET_WITH_SUMMARY: Reset context but include an LLM-generated summary.
 
             .. deprecated:: 0.0.25
-                Use Pipecat's native context summarization instead. See
+                Use Pipecat's native context summarization instead. To trigger
+                on-demand summarization during a node transition, push an
+                ``LLMSummarizeContextFrame`` in a pre-action. See
                 https://docs.pipecat.ai/guides/fundamentals/context-summarization
                 Will be removed in a future version.
     """
@@ -232,7 +234,9 @@ class ContextStrategyConfig:
         summary_prompt: Required prompt text when using RESET_WITH_SUMMARY.
 
             .. deprecated:: 0.0.25
-                Deprecated along with RESET_WITH_SUMMARY. Will be removed in a future version.
+                Deprecated along with RESET_WITH_SUMMARY. Use
+                ``LLMContextSummaryConfig.summarization_prompt`` instead.
+                Will be removed in a future version.
     """
 
     strategy: ContextStrategy

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -211,6 +211,11 @@ class ContextStrategy(Enum):
         APPEND: Append new messages to existing context (default).
         RESET: Reset context with new messages only.
         RESET_WITH_SUMMARY: Reset context but include an LLM-generated summary.
+
+            .. deprecated:: 0.0.25
+                Use Pipecat's native context summarization instead. See
+                https://docs.pipecat.ai/guides/fundamentals/context-summarization
+                Will be removed in a future version.
     """
 
     APPEND = "append"
@@ -225,6 +230,9 @@ class ContextStrategyConfig:
     Parameters:
         strategy: Strategy to use for context management.
         summary_prompt: Required prompt text when using RESET_WITH_SUMMARY.
+
+            .. deprecated:: 0.0.25
+                Deprecated along with RESET_WITH_SUMMARY. Will be removed in a future version.
     """
 
     strategy: ContextStrategy

--- a/tests/test_context_strategies.py
+++ b/tests/test_context_strategies.py
@@ -15,6 +15,7 @@ focusing on:
 """
 
 import unittest
+import warnings
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from pipecat.frames.frames import (
@@ -83,6 +84,40 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         # Invalid configuration - missing prompt
         with self.assertRaises(ValueError):
             ContextStrategyConfig(strategy=ContextStrategy.RESET_WITH_SUMMARY)
+
+    async def test_reset_with_summary_deprecation_warning(self):
+        """Test that RESET_WITH_SUMMARY emits a DeprecationWarning at runtime."""
+        mock_summary = "Conversation summary"
+        self.mock_llm.run_inference.return_value = mock_summary
+
+        flow_manager = FlowManager(
+            task=self.mock_task,
+            llm=self.mock_llm,
+            context_aggregator=self.mock_context_aggregator,
+            context_strategy=ContextStrategyConfig(
+                strategy=ContextStrategy.RESET_WITH_SUMMARY,
+                summary_prompt="Summarize the conversation",
+            ),
+        )
+        await flow_manager.initialize()
+
+        # First node using RESET_WITH_SUMMARY should trigger the deprecation warning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            await flow_manager._set_node("first", self.sample_node)
+
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertTrue(len(deprecation_warnings) >= 1)
+            self.assertIn("RESET_WITH_SUMMARY is deprecated", str(deprecation_warnings[0].message))
+
+        # Second node should NOT trigger a second warning (once-only)
+        self.mock_task.queue_frames.reset_mock()
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            await flow_manager._set_node("second", self.sample_node)
+
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            self.assertEqual(len(deprecation_warnings), 0)
 
     async def test_default_strategy(self):
         """Test default context strategy (APPEND)."""


### PR DESCRIPTION
## Summary

- Deprecate `RESET_WITH_SUMMARY` context strategy in favor of Pipecat's native context summarization (`LLMSummarizeContextFrame`, `LLMContextSummarizer`, auto-summarization on `LLMAssistantAggregatorParams`)
- Emit a runtime `DeprecationWarning` (once per `FlowManager` instance) when `RESET_WITH_SUMMARY` is used, pointing users to the native approach
- Add `.. deprecated::` notices to `ContextStrategy.RESET_WITH_SUMMARY` and `ContextStrategyConfig.summary_prompt` docstrings
- No behavioral changes — `RESET_WITH_SUMMARY` continues to work as before

## Motivation

Native Pipecat summarization is async and non-blocking, making it better suited for real-time applications. Flows' `RESET_WITH_SUMMARY` uses synchronous `adapter.generate_summary()` / `llm.run_inference()`, which blocks the pipeline during summary generation.

## Changes

- **`types.py`**: Added deprecation notices to `RESET_WITH_SUMMARY` enum value and `summary_prompt` field docstrings
- **`manager.py`**: Added `_showed_deprecation_warning_for_reset_with_summary` flag and runtime `DeprecationWarning` in `_update_llm_context()`, following the same pattern as existing deprecations (`tts`, `role_messages`, `set_node`)
- **`test_context_strategies.py`**: Added test verifying the warning is emitted on first use and suppressed on subsequent uses
- **`CHANGELOG.md`**: Added 0.0.25 entry

## Test plan

- [x] `python -m pytest tests/test_context_strategies.py -v` — all 11 tests pass
- [x] `python -m pytest tests/ -v` — full suite (88 tests) passes
- [x] Pre-commit hooks (ruff, ruff-format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)