### PR TITLE
Remove references to OpenAILLMContext for pipecat 1.0 compatibility

### DIFF
--- a/src/pipecat_flows/adapters.py
+++ b/src/pipecat_flows/adapters.py
@@ -26,7 +26,6 @@ from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.processors.aggregators.llm_context import NOT_GIVEN, LLMContext, NotGiven
 from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
-from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 
 from pipecat_flows.types import FlowsDirectFunctionWrapper, FlowsFunctionSchema
 
@@ -158,7 +157,7 @@ class LLMAdapter:
         raise NotImplementedError("Subclasses must implement this method")
 
     async def generate_summary(
-        self, llm: Any, summary_prompt: str, context: OpenAILLMContext | LLMContext
+        self, llm: Any, summary_prompt: str, context: LLMContext
     ) -> Optional[str]:
         """Generate a summary by running a direct one-shot, out-of-band inference with the LLM.
 

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -43,7 +43,6 @@ from pipecat.frames.frames import (
 from pipecat.pipeline.llm_switcher import LLMSwitcher
 from pipecat.pipeline.task import PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
-from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.services.settings import LLMSettings
 from pipecat.transports.base_transport import BaseTransport
@@ -926,7 +925,7 @@ In all of these cases, you can provide a `name` in your new node's config for de
         self._action_manager.schedule_deferred_post_actions(post_actions=post_actions)
 
     async def _create_conversation_summary(
-        self, summary_prompt: str, context: OpenAILLMContext | LLMContext
+        self, summary_prompt: str, context: LLMContext
     ) -> Optional[str]:
         """Generate a conversation summary from a given context."""
         return await self._adapter.generate_summary(self._llm, summary_prompt, context)


### PR DESCRIPTION
pipecat 1.0 removed OpenAILLMContext (along with OpenAILLMContextFrame and OpenAILLMContext.from_messages). Both manager.py and adapters.py imported it purely for use in `OpenAILLMContext | LLMContext` type-hint unions, which made the modules unimportable on pipecat 1.0 with:

  ModuleNotFoundError: No module named
  'pipecat.processors.aggregators.openai_llm_context'

This drops the now-dead import and trims the type-hint unions to `LLMContext`. No behavior change; the `generate_summary` isinstance fallback is left in place (it's unreachable on 1.0 but harmless, and keeping it avoids churning existing tests).

All 88 tests pass against pipecat-ai 1.0.0.