### PR TITLE
Add static JSON flow config example

### DIFF
--- a/examples/food_ordering_static/food_ordering_static.json
+++ b/examples/food_ordering_static/food_ordering_static.json
@@ -1,0 +1,131 @@
+{
+  "initial_node": "initial",
+  "nodes": {
+    "initial": {
+      "role_message": "You are an order-taking assistant. You must ALWAYS use the available functions to progress the conversation. This is a phone conversation and your responses will be converted to audio. Keep the conversation friendly, casual, and polite. Avoid outputting special characters and emojis.",
+      "task_messages": [
+        {
+          "role": "developer",
+          "content": "For this step, ask the user if they want pizza or sushi, and wait for them to use a function to choose. Start off by greeting them. Be friendly and casual; you're taking an order for food over the phone."
+        }
+      ],
+      "pre_actions": [
+        {
+          "type": "function",
+          "handler": "check_kitchen_status"
+        }
+      ],
+      "functions": [
+        {
+          "name": "choose_pizza",
+          "description": "User wants to order pizza. Let's get that order started.",
+          "transition_to": "choose_pizza"
+        },
+        {
+          "name": "choose_sushi",
+          "description": "User wants to order sushi. Let's get that order started.",
+          "transition_to": "choose_sushi"
+        }
+      ]
+    },
+    "choose_pizza": {
+      "task_messages": [
+        {
+          "role": "developer",
+          "content": "You are handling a pizza order. Use the available functions:\n- Use select_pizza_order when the user specifies both size AND type\n\nPricing:\n- Small: $10\n- Medium: $15\n- Large: $20\n\nRemember to be friendly and casual."
+        }
+      ],
+      "functions": [
+        {
+          "name": "select_pizza_order",
+          "description": "Record the pizza order details",
+          "properties": {
+            "size": {
+              "type": "string",
+              "enum": ["small", "medium", "large"],
+              "description": "Size of the pizza"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["pepperoni", "cheese", "supreme", "vegetarian"],
+              "description": "Type of pizza"
+            }
+          },
+          "required": ["size", "type"],
+          "handler": "select_pizza_order",
+          "transition_to": "confirm"
+        }
+      ]
+    },
+    "choose_sushi": {
+      "task_messages": [
+        {
+          "role": "developer",
+          "content": "You are handling a sushi order. Use the available functions:\n- Use select_sushi_order when the user specifies both count AND type\n\nPricing:\n- $8 per roll\n\nRemember to be friendly and casual."
+        }
+      ],
+      "functions": [
+        {
+          "name": "select_sushi_order",
+          "description": "Record the sushi order details",
+          "properties": {
+            "count": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10,
+              "description": "Number of rolls to order"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["california", "spicy tuna", "rainbow", "dragon"],
+              "description": "Type of sushi roll"
+            }
+          },
+          "required": ["count", "type"],
+          "handler": "select_sushi_order",
+          "transition_to": "confirm"
+        }
+      ]
+    },
+    "confirm": {
+      "task_messages": [
+        {
+          "role": "developer",
+          "content": "Read back the complete order details to the user and ask if they want anything else or if they want to make changes. Use the available functions:\n- Use complete_order when the user confirms that the order is correct and no changes are needed\n- Use revise_order if they want to change something\n\nBe friendly and clear when reading back the order details."
+        }
+      ],
+      "functions": [
+        {
+          "name": "complete_order",
+          "description": "User confirms the order is correct",
+          "transition_to": "end"
+        },
+        {
+          "name": "revise_order",
+          "description": "User wants to make changes to their order",
+          "transition_to": "initial"
+        }
+      ]
+    },
+    "end": {
+      "task_messages": [
+        {
+          "role": "developer",
+          "content": "Thank the user for their order and end the conversation politely and concisely."
+        }
+      ],
+      "post_actions": [
+        {
+          "type": "end_conversation"
+        }
+      ]
+    }
+  },
+  "global_functions": [
+    {
+      "name": "get_delivery_estimate",
+      "description": "Get a delivery estimate for the current order",
+      "handler": "get_delivery_estimate"
+    }
+  ]
+}

--- a/examples/food_ordering_static/food_ordering_static.py
+++ b/examples/food_ordering_static/food_ordering_static.py
@@ -1,0 +1,220 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""A food ordering flow example using static JSON configuration.
+
+This example demonstrates the same food ordering system as food_ordering.py,
+but with the flow graph defined in a static JSON file. Custom computation
+(pricing, state updates) still happens in Python handler functions.
+
+JSONFlowConfig (in json_flow_config.py) bridges JSON and Pipecat Flows:
+- Simple transitions (choose_pizza, choose_sushi) are auto-generated from JSON
+- Functions with custom logic (select_pizza_order) use registered Python handlers
+- The JSON file defines the complete flow graph without any Python code
+
+Multi-LLM Support:
+Set LLM_PROVIDER environment variable to choose your LLM provider.
+Supported: openai_responses (default), openai, anthropic, google, aws
+
+Requirements:
+- CARTESIA_API_KEY (for TTS)
+- DEEPGRAM_API_KEY (for STT)
+- DAILY_API_KEY (for transport)
+- LLM API key (varies by provider - see env.example)
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from dotenv import load_dotenv
+from loguru import logger
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import create_transport
+from pipecat.services.cartesia.tts import CartesiaTTSService
+from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.transports.base_transport import BaseTransport, TransportParams
+from pipecat.transports.daily.transport import DailyParams
+from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
+
+# Add parent directory to path so we can import the shared utils module
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from json_flow_config import JSONFlowConfig  # noqa: E402
+from utils import create_llm  # noqa: E402
+
+from pipecat_flows import FlowArgs, FlowManager, FlowResult
+
+load_dotenv(override=True)
+
+transport_params = {
+    "daily": lambda: DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "twilio": lambda: FastAPIWebsocketParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+    "webrtc": lambda: TransportParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+    ),
+}
+
+
+# --- Handler functions ---
+
+
+async def select_pizza_order(args: FlowArgs, flow_manager: FlowManager) -> FlowResult:
+    """Handle pizza size and type selection."""
+    size = args["size"]
+    pizza_type = args["type"]
+
+    # Simple pricing
+    base_price = {"small": 10.00, "medium": 15.00, "large": 20.00}
+    price = base_price[size]
+
+    # Store order details in flow state
+    flow_manager.state["order"] = {
+        "type": "pizza",
+        "size": size,
+        "pizza_type": pizza_type,
+        "price": price,
+    }
+
+    return {"size": size, "type": pizza_type, "price": price}
+
+
+async def select_sushi_order(args: FlowArgs, flow_manager: FlowManager) -> FlowResult:
+    """Handle sushi roll count and type selection."""
+    count = args["count"]
+    roll_type = args["type"]
+
+    # Simple pricing: $8 per roll
+    price = count * 8.00
+
+    # Store order details in flow state
+    flow_manager.state["order"] = {
+        "type": "sushi",
+        "count": count,
+        "roll_type": roll_type,
+        "price": price,
+    }
+
+    return {"count": count, "type": roll_type, "price": price}
+
+
+async def get_delivery_estimate(args: FlowArgs, flow_manager: FlowManager) -> FlowResult:
+    """Provide delivery estimate information."""
+    delivery_time = datetime.now() + timedelta(minutes=30)
+    return {"time": str(delivery_time)}
+
+
+# Pre-action handler
+
+
+async def check_kitchen_status(action: dict, flow_manager: FlowManager) -> None:
+    """Check if kitchen is open and log status."""
+    logger.info("Checking kitchen status")
+
+
+# --- Pipeline setup ---
+
+
+async def run_bot(transport: BaseTransport, runner_args: RunnerArguments):
+    """Run the food ordering bot."""
+    stt = DeepgramSTTService(api_key=os.getenv("DEEPGRAM_API_KEY"))
+    tts = CartesiaTTSService(
+        api_key=os.getenv("CARTESIA_API_KEY"),
+        settings=CartesiaTTSService.Settings(
+            voice="820a3788-2b37-4d21-847a-b65d8a68c99a",  # Salesman
+        ),
+    )
+    # LLM service is created using the create_llm function from utils.py
+    # Default is OpenAI; can be changed by setting LLM_PROVIDER environment variable
+    llm = create_llm()
+
+    context = LLMContext()
+    context_aggregator = LLMContextAggregatorPair(
+        context,
+        user_params=LLMUserAggregatorParams(
+            vad_analyzer=SileroVADAnalyzer(),
+            filter_incomplete_user_turns=True,
+        ),
+    )
+
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            stt,
+            context_aggregator.user(),
+            llm,
+            tts,
+            transport.output(),
+            context_aggregator.assistant(),
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+        idle_timeout_secs=runner_args.pipeline_idle_timeout_secs,
+    )
+
+    # Load flow config from JSON. Handler strings in the JSON are resolved
+    # against the module namespace -- function names just need to match.
+    flow_config = JSONFlowConfig(
+        Path(__file__).parent / "food_ordering_static.json",
+        globals(),
+    )
+
+    # Initialize flow manager with global functions from config
+    flow_manager = FlowManager(
+        task=task,
+        llm=llm,
+        context_aggregator=context_aggregator,
+        transport=transport,
+        global_functions=flow_config.create_global_functions(),
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info("Client connected")
+        # Kick off the conversation with the initial node
+        await flow_manager.initialize(flow_config.create_initial_node())
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info("Client disconnected")
+        await task.cancel()
+
+    runner = PipelineRunner(handle_sigint=runner_args.handle_sigint)
+    await runner.run(task)
+
+
+async def bot(runner_args: RunnerArguments):
+    """Main bot entry point compatible with Pipecat Cloud."""
+    transport = await create_transport(runner_args, transport_params)
+    await run_bot(transport, runner_args)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/examples/food_ordering_static/json_flow_config.py
+++ b/examples/food_ordering_static/json_flow_config.py
@@ -1,0 +1,208 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""JSON-based flow configuration adapter for Pipecat Flows.
+
+Bridges a static JSON flow definition and Pipecat Flows. The flow graph
+(nodes, messages, function schemas, transitions) lives in JSON, while
+custom computation still happens in Python handler functions resolved from
+a namespace dict (typically ``globals()``).
+
+Function resolution rules:
+    - transition_to only: auto-generates a handler that returns (None, next_node)
+    - handler + transition_to: resolves handler from namespace, wraps result with next_node
+    - handler only: resolves handler from namespace, no transition (returns result, None)
+    - neither: raises ValueError at validation time
+"""
+
+import json
+from pathlib import Path
+from typing import Callable
+
+from pipecat_flows import (
+    ContextStrategy,
+    ContextStrategyConfig,
+    FlowArgs,
+    FlowManager,
+    FlowsFunctionSchema,
+    NodeConfig,
+)
+
+
+class JSONFlowConfig:
+    """Bridges a static JSON flow definition and Pipecat Flows.
+
+    Reads a JSON config that defines the flow graph (nodes, messages, function
+    schemas, transitions) and produces NodeConfig objects at runtime. Simple
+    transitions are auto-generated; functions that need custom logic reference
+    Python handlers by name, resolved from the provided namespace dict.
+
+    Args:
+        config: A dict, JSON string, or path to a JSON file.
+        namespace: A dict mapping names to callables (typically ``globals()``).
+            Handler strings in the JSON config are resolved against this dict
+            lazily at node creation time.
+    """
+
+    def __init__(self, config: dict | str | Path, namespace: dict):
+        self._config = self._load_config(config)
+        self._namespace = namespace
+        self._validate()
+
+    def _load_config(self, config: dict | str | Path) -> dict:
+        """Parse dict, JSON string, or file path into a config dict."""
+        if isinstance(config, dict):
+            return config
+        if isinstance(config, Path):
+            return json.loads(config.read_text())
+        path = Path(config)
+        if path.exists():
+            return json.loads(path.read_text())
+        return json.loads(config)
+
+    def _validate(self) -> None:
+        """Validate structural correctness at load time."""
+        initial = self._config.get("initial_node")
+        nodes = self._config.get("nodes", {})
+
+        if not initial:
+            raise ValueError("Config missing 'initial_node'")
+        if initial not in nodes:
+            raise ValueError(f"initial_node '{initial}' not found in nodes")
+
+        # Collect all function definitions for validation
+        all_functions: list[tuple[dict, str | None]] = []
+        for node_name, node in nodes.items():
+            for func in node.get("functions", []):
+                all_functions.append((func, node_name))
+        for func in self._config.get("global_functions", []):
+            all_functions.append((func, None))
+
+        for func, source in all_functions:
+            has_handler = "handler" in func
+            has_transition = "transition_to" in func
+            location = f"node '{source}'" if source else "global functions"
+            if not has_handler and not has_transition:
+                raise ValueError(
+                    f"Function '{func['name']}' in {location} "
+                    "must have at least one of 'handler' or 'transition_to'"
+                )
+            if has_transition and func["transition_to"] not in nodes:
+                raise ValueError(
+                    f"Function '{func['name']}' in {location} "
+                    f"references unknown node '{func['transition_to']}'"
+                )
+
+    def _build_function(self, func_def: dict) -> FlowsFunctionSchema:
+        """Convert a JSON function definition into a FlowsFunctionSchema."""
+        has_handler = "handler" in func_def
+        has_transition = "transition_to" in func_def
+
+        if has_handler and has_transition:
+            handler = self._make_wrapped_handler(func_def["handler"], func_def["transition_to"])
+        elif has_transition:
+            handler = self._make_transition_handler(func_def["transition_to"])
+        else:
+            handler = self._make_passthrough_handler(func_def["handler"])
+
+        return FlowsFunctionSchema(
+            name=func_def["name"],
+            handler=handler,
+            description=func_def.get("description", ""),
+            properties=func_def.get("properties", {}),
+            required=func_def.get("required", []),
+        )
+
+    def _make_transition_handler(self, target_node: str) -> Callable:
+        """Auto-generate a handler that just transitions to the target node."""
+
+        async def handler(args: FlowArgs, flow_manager: FlowManager):
+            return None, self.create_node(target_node)
+
+        return handler
+
+    def _make_wrapped_handler(self, handler_name: str, target_node: str) -> Callable:
+        """Resolve a handler from the namespace and pair its result with the target node."""
+
+        async def handler(args: FlowArgs, flow_manager: FlowManager):
+            resolved = self._namespace.get(handler_name)
+            if not resolved:
+                raise ValueError(f"Handler '{handler_name}' not found in namespace")
+            result = await resolved(args, flow_manager)
+            return result, self.create_node(target_node)
+
+        return handler
+
+    def _make_passthrough_handler(self, handler_name: str) -> Callable:
+        """Resolve a handler from the namespace that stays on the current node."""
+
+        async def handler(args: FlowArgs, flow_manager: FlowManager):
+            resolved = self._namespace.get(handler_name)
+            if not resolved:
+                raise ValueError(f"Handler '{handler_name}' not found in namespace")
+            result = await resolved(args, flow_manager)
+            return result, None
+
+        return handler
+
+    def _resolve_actions(self, actions: list[dict] | None) -> list[dict] | None:
+        """Resolve string handler references in function-type actions to callables."""
+        if not actions:
+            return None
+        resolved = []
+        for action in actions:
+            action = dict(action)  # Copy to avoid mutating the config
+            if action.get("type") == "function" and isinstance(action.get("handler"), str):
+                handler_name = action["handler"]
+                handler = self._namespace.get(handler_name)
+                if not handler:
+                    raise ValueError(f"Action handler '{handler_name}' not found in namespace")
+                action["handler"] = handler
+            resolved.append(action)
+        return resolved
+
+    def create_node(self, node_name: str) -> NodeConfig:
+        """Build a NodeConfig from the JSON definition for the given node."""
+        node_def = self._config["nodes"][node_name]
+
+        node: NodeConfig = {
+            "name": node_name,
+            "task_messages": node_def["task_messages"],
+        }
+
+        if "role_message" in node_def:
+            node["role_message"] = node_def["role_message"]
+
+        if "functions" in node_def:
+            node["functions"] = [self._build_function(f) for f in node_def["functions"]]
+
+        pre_actions = self._resolve_actions(node_def.get("pre_actions"))
+        if pre_actions:
+            node["pre_actions"] = pre_actions
+
+        post_actions = self._resolve_actions(node_def.get("post_actions"))
+        if post_actions:
+            node["post_actions"] = post_actions
+
+        if "context_strategy" in node_def:
+            cs = node_def["context_strategy"]
+            node["context_strategy"] = ContextStrategyConfig(
+                strategy=ContextStrategy(cs["strategy"]),
+                summary_prompt=cs.get("summary_prompt"),
+            )
+
+        if "respond_immediately" in node_def:
+            node["respond_immediately"] = node_def["respond_immediately"]
+
+        return node
+
+    def create_initial_node(self) -> NodeConfig:
+        """Build the NodeConfig for the initial node defined in the config."""
+        return self.create_node(self._config["initial_node"])
+
+    def create_global_functions(self) -> list[FlowsFunctionSchema]:
+        """Build FlowsFunctionSchema objects for all global functions in the config."""
+        return [self._build_function(f) for f in self._config.get("global_functions", [])]


### PR DESCRIPTION
## Context

In moving to 1.0.0, static flows are deprecated. I'm creating this example as a draft of how to use a JSON configuration with the FlowManager. This isn't the only way to work, but it demonstrates that the underlying FlowManager is capable of working with a static flow, even though it isn't part of the API.

I'm not sure if this adapter will become part of Flows. For now, I just want to create and share an example to demonstrate a possibility.

## Summary

- Adds a `food_ordering_static` example that defines the entire flow graph in JSON, with a `JSONFlowConfig` adapter that bridges the JSON definition and `FlowManager`
- Handler strings in JSON (e.g. `"handler": "select_pizza_order"`) are resolved from a namespace dict (`globals()`) lazily at node creation time, matching how dynamic flows work
- The adapter is kept as a standalone example file, not part of the library -- users can copy and adapt it for their own JSON schema and resolution strategy

## Test plan

- [x] `uv run ruff format examples/food_ordering_static/` passes
- [x] `uv run ruff check examples/food_ordering_static/` passes
- [ ] Manual: `uv run examples/food_ordering_static/food_ordering_static.py` (requires API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)