### PR TITLE
Modernize typing

### DIFF
--- a/examples/insurance_quote.py
+++ b/examples/insurance_quote.py
@@ -264,7 +264,7 @@ def create_quote_calculation_node(age: int, marital_status: str) -> NodeConfig:
 
 
 def create_quote_results_node(
-    quote: Union[QuoteCalculationResult, CoverageUpdateResult],
+    quote: QuoteCalculationResult | CoverageUpdateResult,
 ) -> NodeConfig:
     """Create node for showing quote and adjustment options."""
     return {

--- a/examples/patient_intake.py
+++ b/examples/patient_intake.py
@@ -28,7 +28,7 @@ Requirements:
 """
 
 import os
-from typing import List, TypedDict
+from typing import TypedDict
 
 from dotenv import load_dotenv
 from loguru import logger
@@ -137,7 +137,7 @@ async def record_prescriptions(
     args: FlowArgs, flow_manager: FlowManager
 ) -> tuple[PrescriptionRecordResult, NodeConfig]:
     """Handler for recording prescriptions."""
-    prescriptions: List[Prescription] = args["prescriptions"]
+    prescriptions: list[Prescription] = args["prescriptions"]
 
     # Store prescriptions in flow state
     flow_manager.state["prescriptions"] = prescriptions
@@ -150,7 +150,7 @@ async def record_allergies(
     args: FlowArgs, flow_manager: FlowManager
 ) -> tuple[AllergyRecordResult, NodeConfig]:
     """Handler for recording allergies."""
-    allergies: List[Allergy] = args["allergies"]
+    allergies: list[Allergy] = args["allergies"]
 
     # Store allergies in flow state
     flow_manager.state["allergies"] = allergies
@@ -163,7 +163,7 @@ async def record_conditions(
     args: FlowArgs, flow_manager: FlowManager
 ) -> tuple[ConditionRecordResult, NodeConfig]:
     """Handler for recording medical conditions."""
-    conditions: List[Condition] = args["conditions"]
+    conditions: list[Condition] = args["conditions"]
 
     # Store conditions in flow state
     flow_manager.state["conditions"] = conditions
@@ -176,7 +176,7 @@ async def record_visit_reasons(
     args: FlowArgs, flow_manager: FlowManager
 ) -> tuple[VisitReasonRecordResult, NodeConfig]:
     """Handler for recording visit reasons."""
-    visit_reasons: List[VisitReason] = args["visit_reasons"]
+    visit_reasons: list[VisitReason] = args["visit_reasons"]
 
     # Store visit reasons in flow state
     flow_manager.state["visit_reasons"] = visit_reasons

--- a/examples/warm_transfer.py
+++ b/examples/warm_transfer.py
@@ -45,7 +45,7 @@ import atexit
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import aiohttp
 from dotenv import load_dotenv
@@ -676,7 +676,7 @@ async def main():
         # Set up event handlers
         @transport.event_handler("on_first_participant_joined")
         async def on_first_participant_joined(
-            transport: DailyTransport, participant: Dict[str, Any]
+            transport: DailyTransport, participant: dict[str, Any]
         ):
             """Start the flow.
             We're assuming the first participant is the customer and not the human agent.
@@ -686,7 +686,7 @@ async def main():
             await flow_manager.initialize(create_initial_customer_interaction_node())
 
         @transport.event_handler("on_participant_joined")
-        async def on_participant_joined(transport: DailyTransport, participant: Dict[str, Any]):
+        async def on_participant_joined(transport: DailyTransport, participant: dict[str, Any]):
             """Handle the human agent maybe having joined the call:
             - If the participant who joined is the human agent and we're currently in the "transferring_to_human_agent" node, go to the "human_agent_interaction" node.
             - Otherwise...nothing, for the purposes of this demo. We're assuming the human agent won't join while the conversation flow is any other node.
@@ -697,7 +697,7 @@ async def main():
 
         @transport.event_handler("on_participant_left")
         async def on_participant_left(
-            transport: DailyTransport, participant: Dict[str, Any], reason: str
+            transport: DailyTransport, participant: dict[str, Any], reason: str
         ):
             # NOTE: an opportunity for refinement here is to handle the customer leaving while on
             # hold, informing the human agent if needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ line-length = 100
 select = [
     "D", # Docstring rules
     "I", # Import rules
+    "UP", # Modern Python
 ]
 ignore = [
     "D105",  # Missing docstring in magic methods (__str__, __repr__, etc.)

--- a/src/pipecat_flows/actions.py
+++ b/src/pipecat_flows/actions.py
@@ -25,8 +25,9 @@ Actions are used to perform side effects during conversations, such as:
 
 import asyncio
 import inspect
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from loguru import logger
 from pipecat.frames.frames import (

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -27,7 +27,8 @@ The flow manager coordinates all aspects of a conversation, including:
 import asyncio
 import inspect
 import warnings
-from typing import Any, Callable, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 from loguru import logger
 from pipecat.frames.frames import (
@@ -795,7 +796,7 @@ class FlowManager:
                         )
                         update_config.strategy = ContextStrategy.APPEND
 
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     logger.warning("Summary generation timed out, falling back to APPEND strategy")
                     update_config.strategy = ContextStrategy.APPEND
 

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -18,14 +18,12 @@ and function interactions.
 """
 
 import uuid
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
-    Mapping,
     Protocol,
     Required,
     TypedDict,

--- a/tests/test_flows_direct_functions.py
+++ b/tests/test_flows_direct_functions.py
@@ -69,7 +69,7 @@ class TestFlowsDirectFunction(unittest.TestCase):
         self.assertEqual(func.properties, {})
 
         async def my_function_simple_params(
-            flow_manager: FlowManager, name: str, age: int, height: Union[float, None]
+            flow_manager: FlowManager, name: str, age: int, height: float | None
         ):
             return {"status": "success"}, None
 
@@ -88,7 +88,7 @@ class TestFlowsDirectFunction(unittest.TestCase):
             flow_manager: FlowManager,
             address_lines: list[str],
             nickname: str | int | float,
-            extra: Optional[dict[str, str]],
+            extra: dict[str, str] | None,
         ):
             return {"status": "success"}, None
 
@@ -159,7 +159,7 @@ class TestFlowsDirectFunction(unittest.TestCase):
         self.assertEqual(func.required, [])
 
         async def my_function_simple_params(
-            flow_manager: FlowManager, name: str, age: int, height: Union[float, None] = None
+            flow_manager: FlowManager, name: str, age: int, height: float | None = None
         ):
             return {"status": "success"}, None
 
@@ -169,9 +169,9 @@ class TestFlowsDirectFunction(unittest.TestCase):
 
         async def my_function_complex_params(
             flow_manager: FlowManager,
-            address_lines: Optional[list[str]],
+            address_lines: list[str] | None,
             nickname: str | int = "Bud",
-            extra: Optional[dict[str, str]] = None,
+            extra: dict[str, str] | None = None,
         ):
             return {"status": "success"}, None
 
@@ -182,9 +182,7 @@ class TestFlowsDirectFunction(unittest.TestCase):
     def test_property_descriptions_are_set_from_function(self):
         """Test that FlowsDirectFunction extracts the property descriptions from the function."""
 
-        async def my_function(
-            flow_manager: FlowManager, name: str, age: int, height: Union[float, None]
-        ):
+        async def my_function(flow_manager: FlowManager, name: str, age: int, height: float | None):
             """
             This is a test function.
 


### PR DESCRIPTION
## Summary
- Enable ruff's `UP` (pyupgrade) lint rule to enforce modern Python idioms
- Replace deprecated `typing` imports (`List`, `Dict`, `Callable`, `Optional`, `Union`, `Awaitable`, `Mapping`) with modern equivalents (`list`, `dict`, `collections.abc`, `X | Y` syntax) across source, examples, and tests

## Test plan
- [x] `ruff check .` passes with no errors
- [x] Pre-commit hooks pass (ruff + ruff-format)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)