### PR TITLE
Re-register function handlers when a node redeclares them

### DIFF
--- a/changelog/270.fixed.md
+++ b/changelog/270.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an issue where redeclaring a function in a new node silently kept the previous node's handler bound (#269).

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -527,7 +527,11 @@ class FlowManager:
         cancel_on_interruption: bool = True,
         timeout_secs: float | None = None,
     ) -> None:
-        """Register a function with the LLM if not already registered.
+        """Register a function with the LLM.
+
+        Always re-registers so a node redeclaring a function with a different
+        handler replaces the previous binding. ``LLMService.register_function``
+        is a dict upsert by name, so re-registration is idempotent.
 
         Args:
             name: Name of the function to register
@@ -541,27 +545,26 @@ class FlowManager:
         Raises:
             FlowError: If function registration fails
         """
-        if name not in self._current_functions:
-            try:
-                # Create transition function
-                transition_func = await self._create_transition_func(name, handler)
+        try:
+            # Create transition function
+            transition_func = await self._create_transition_func(name, handler)
 
-                # Register function with LLM (or LLMSwitcher)
-                kwargs = {}
-                if timeout_secs is not None:
-                    kwargs["timeout_secs"] = timeout_secs
-                self._llm.register_function(
-                    name,
-                    transition_func,
-                    cancel_on_interruption=cancel_on_interruption,
-                    **kwargs,
-                )
+            # Register function with LLM (or LLMSwitcher)
+            kwargs = {}
+            if timeout_secs is not None:
+                kwargs["timeout_secs"] = timeout_secs
+            self._llm.register_function(
+                name,
+                transition_func,
+                cancel_on_interruption=cancel_on_interruption,
+                **kwargs,
+            )
 
-                new_functions.add(name)
-                logger.debug(f"Registered function: {name}")
-            except Exception as e:
-                logger.error(f"Failed to register function {name}: {str(e)}")
-                raise FlowError(f"Function registration failed: {str(e)}") from e
+            new_functions.add(name)
+            logger.debug(f"Registered function: {name}")
+        except Exception as e:
+            logger.error(f"Failed to register function {name}: {str(e)}")
+            raise FlowError(f"Function registration failed: {str(e)}") from e
 
     async def set_node_from_config(self, node_config: NodeConfig) -> None:
         """Set up a new conversation node and transition to it.

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -270,6 +270,100 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.mock_llm.register_function.call_count, 3)
         self.assertEqual(len(flow_manager._current_functions), 3)
 
+    async def test_redeclared_function_rebinds_new_handler(self):
+        """Regression: redeclaring a function in a new node must bind the new handler.
+
+        Two adjacent nodes declare ``go`` with different handlers returning
+        different next nodes. The LLM-registered handler for ``go`` must reflect
+        the latest node's handler, not the first one's.
+
+        See https://github.com/pipecat-ai/pipecat-flows/issues/269.
+        """
+        flow_manager = FlowManager(
+            task=self.mock_task,
+            llm=self.mock_llm,
+            context_aggregator=self.mock_context_aggregator,
+        )
+        await flow_manager.initialize()
+
+        handler_a_calls = []
+        handler_b_calls = []
+
+        async def handler_a(args, flow_manager):
+            handler_a_calls.append(args)
+            return {"from": "A"}, {
+                "task_messages": [{"role": "developer", "content": "menu"}],
+                "functions": [],
+            }
+
+        async def handler_b(args, flow_manager):
+            handler_b_calls.append(args)
+            return {"from": "B"}, {
+                "task_messages": [{"role": "developer", "content": "home"}],
+                "functions": [],
+            }
+
+        await flow_manager.set_node_from_config(
+            {
+                "task_messages": [{"role": "developer", "content": "A"}],
+                "functions": [
+                    FlowsFunctionSchema(
+                        name="go",
+                        description="A's go",
+                        properties={},
+                        required=[],
+                        handler=handler_a,
+                    ),
+                ],
+            }
+        )
+        await flow_manager.set_node_from_config(
+            {
+                "task_messages": [{"role": "developer", "content": "B"}],
+                "functions": [
+                    FlowsFunctionSchema(
+                        name="go",
+                        description="B's go",
+                        properties={},
+                        required=[],
+                        handler=handler_b,
+                    ),
+                ],
+            }
+        )
+
+        # ``go`` must be registered for both nodes, not just the first one.
+        go_registrations = [
+            call_args
+            for call_args in self.mock_llm.register_function.call_args_list
+            if call_args[0][0] == "go"
+        ]
+        self.assertEqual(
+            len(go_registrations),
+            2,
+            "Expected 'go' to be re-registered when node B redeclared it; "
+            f"got {len(go_registrations)} registration(s).",
+        )
+
+        # Drive the most recent transition_func and confirm handler_b runs.
+        latest_go = go_registrations[-1][0][1]
+
+        async def result_callback(result, *, properties=None):
+            pass
+
+        params = FunctionCallParams(
+            function_name="go",
+            tool_call_id="t1",
+            arguments={},
+            llm=None,
+            context=None,
+            result_callback=result_callback,
+        )
+        await latest_go(params)
+
+        self.assertEqual(len(handler_b_calls), 1, "handler_b should have run")
+        self.assertEqual(len(handler_a_calls), 0, "handler_a should NOT have run")
+
     async def test_initialize_already_initialized(self):
         """Test initializing an already initialized flow manager."""
         flow_manager = FlowManager(


### PR DESCRIPTION
## Summary

- Drop the `name not in self._current_functions` guard in
  `FlowManager._register_function` so that handlers are re-registered with the
  LLM each time a node redeclares a function.
- Add `test_redeclared_function_rebinds_new_handler` in `tests/test_manager.py`
  asserting the new handler wins after re-declaration.

Fixes #269.

## Background

When two adjacent nodes declared the same function name with different
handlers, the OpenAI tool schema reaching the LLM was correctly updated to the
second node's version, but the handler closure stayed bound to the first
node's. Result: the LLM called the function expecting node B's behaviour, but
node A's transition fired — silently, no warning.

## Test plan

- [x] New regression test fails on `main` and passes after the fix.
- [x] `uv run pytest tests/` — 61 tests pass locally
      (`test_context_strategies.py` skipped — local env lacks the `google-genai`
      extra; behaviourally unrelated to this change).
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] Changelog fragment to be added in a follow-up commit once the PR number
      is assigned.

