### PR TITLE
Resolve `ConsolidatedFunctionResult` without requiring `NodeConfig` import

### DIFF
--- a/changelog/272.fixed.md
+++ b/changelog/272.fixed.md
@@ -1,0 +1,1 @@
+- Fixed an unresolved `NodeConfig` forward reference in `ConsolidatedFunctionResult` that caused `get_type_hints()` (and therefore Pipecat's `BaseDirectFunctionWrapper`) to raise `NameError: name 'NodeConfig' is not defined` on direct functions annotated with `-> ConsolidatedFunctionResult`, stalling flows at node-setup time (#271).

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -78,89 +78,6 @@ Example::
     }
 """
 
-ConsolidatedFunctionResult = tuple[Any, "NodeConfig | None"]
-"""Return type for "consolidated" functions.
-
-Return type for "consolidated" functions that do either or both of:
-- doing some work
-- specifying the next node to transition to after the work is done
-
-The first tuple element is the function-call result delivered to the LLM.
-Any JSON-serializable value is accepted (matching Pipecat's upstream
-``FunctionCallResultCallback`` contract). Pass ``None`` to signal a
-transition-only handler; FlowManager substitutes an acknowledgement result.
-"""
-
-ZeroArgFunctionHandler = Callable[[], Awaitable[Any]]
-"""Function handler that takes no arguments.
-
-.. deprecated:: 1.x.0
-    Use :data:`FlowFunctionHandler` (``(args, flow_manager)``) instead. Will be
-    removed in 2.0.0.
-
-Returns:
-    Any JSON-serializable value, or a :data:`ConsolidatedFunctionResult`
-    tuple to also specify the next node.
-"""
-
-LegacyFunctionHandler = Callable[[FlowArgs], Awaitable[Any]]
-"""Legacy function handler that only receives arguments.
-
-.. deprecated:: 1.x.0
-    Use :data:`FlowFunctionHandler` (``(args, flow_manager)``) instead. Will be
-    removed in 2.0.0.
-
-Args:
-    args: Dictionary of arguments from the function call.
-
-Returns:
-    Any JSON-serializable value, or a :data:`ConsolidatedFunctionResult`
-    tuple to also specify the next node.
-"""
-
-FlowFunctionHandler = Callable[[FlowArgs, "FlowManager"], Awaitable[Any]]
-"""Modern function handler that receives both arguments and flow_manager.
-
-Args:
-    args: Dictionary of arguments from the function call.
-    flow_manager: Reference to the FlowManager instance.
-
-Returns:
-    Any JSON-serializable value, or a :data:`ConsolidatedFunctionResult`
-    tuple to also specify the next node.
-"""
-
-
-FunctionHandler = ZeroArgFunctionHandler | LegacyFunctionHandler | FlowFunctionHandler
-"""Union type for function handlers supporting 0-arg, legacy, and modern patterns."""
-
-
-FlowsDirectFunction = Callable[..., Awaitable[ConsolidatedFunctionResult]]
-"""Type alias for "direct" functions with automatic metadata extraction.
-
-"Direct" functions have their definition automatically extracted from the
-function signature and docstring. This can be used in :data:`NodeConfig`
-directly, in lieu of a :class:`FlowsFunctionSchema` or function definition
-dict.
-
-Expected shape:
-
-.. code-block:: python
-
-    async def f(flow_manager: FlowManager, **params) -> ConsolidatedFunctionResult:
-        ...
-
-where ``**params`` are any named parameters described by the function's
-docstring.
-
-This is defined as ``Callable[..., ...]`` rather than a Protocol because
-Python's Protocol system cannot express "any concrete named-parameter list"
-against ``**kwargs: Any`` — a function with named params like ``llm: str``
-is not structurally compatible with a ``**kwargs: Any`` protocol signature.
-Runtime validation of the expected shape happens in
-:meth:`FlowsDirectFunctionWrapper.validate_function`.
-"""
-
 
 LegacyActionHandler = Callable[[dict[str, Any]], Awaitable[None]]
 """Legacy action handler type that only receives the action dictionary.
@@ -255,6 +172,155 @@ class ContextStrategyConfig:
         """
         if self.strategy == ContextStrategy.RESET_WITH_SUMMARY and not self.summary_prompt:
             raise ValueError("summary_prompt is required when using RESET_WITH_SUMMARY strategy")
+
+
+class NodeConfig(TypedDict, total=False):
+    """Configuration for a single node in the flow.
+
+    Parameters:
+        task_messages: List of message dicts defining the current node's objectives.
+        name: Name of the node, useful for debug logging when returning a next node
+            from a "consolidated" function.
+        role_message: The bot's role/personality as a plain string, sent as the
+            LLM's system instruction via ``LLMUpdateSettingsFrame``. When
+            provided, the system instruction persists across node transitions
+            until a new node explicitly sets ``role_message`` again.
+        role_messages: Deprecated list-of-dicts format for the bot's role/personality.
+
+            .. deprecated:: 0.0.24
+                Use ``role_message`` (str) instead. Will be removed in 2.0.0.
+
+        functions: List of FlowsFunctionSchema definitions or direct functions
+            whose definitions are automatically extracted from their signatures.
+        pre_actions: Actions to execute before LLM inference.
+        post_actions: Actions to execute after LLM inference.
+        context_strategy: Strategy for updating context during transitions.
+        respond_immediately: Whether to run LLM inference as soon as the node is
+            set (default: True).
+
+    Example::
+
+        {
+            "role_message": "You are a helpful assistant...",
+            "task_messages": [
+                {
+                    "role": "developer",
+                    "content": "Ask the user for their name..."
+                }
+            ],
+            "functions": [...],
+            "pre_actions": [...],
+            "post_actions": [...],
+            "context_strategy": ContextStrategyConfig(strategy=ContextStrategy.APPEND),
+            "respond_immediately": true,
+        }
+    """
+
+    task_messages: Required[list[dict]]
+    name: str
+    role_message: str
+    role_messages: list[dict[str, Any]]
+    # ``FlowsFunctionSchema`` and ``FlowsDirectFunction`` are defined below
+    # (see the note above ``ConsolidatedFunctionResult``); string forward
+    # references keep ``NodeConfig`` definable here without re-introducing the
+    # cross-module forward reference that ``ConsolidatedFunctionResult`` used
+    # to require.
+    functions: "list[FlowsFunctionSchema | FlowsDirectFunction]"
+    pre_actions: list[ActionConfig]
+    post_actions: list[ActionConfig]
+    context_strategy: ContextStrategyConfig
+    respond_immediately: bool
+
+
+# ``ConsolidatedFunctionResult`` is the public return-type alias for "direct"
+# functions. It must be defined **after** ``NodeConfig`` and without a string
+# forward reference: ``get_type_hints()`` on a user-defined direct function
+# resolves names against the user's module globals, not this module's, so a
+# ``"NodeConfig"`` forward reference here would fail unless the user happened
+# to import ``NodeConfig`` themselves.
+ConsolidatedFunctionResult = tuple[Any, NodeConfig | None]
+"""Return type for "consolidated" functions.
+
+Return type for "consolidated" functions that do either or both of:
+- doing some work
+- specifying the next node to transition to after the work is done
+
+The first tuple element is the function-call result delivered to the LLM.
+Any JSON-serializable value is accepted (matching Pipecat's upstream
+``FunctionCallResultCallback`` contract). Pass ``None`` to signal a
+transition-only handler; FlowManager substitutes an acknowledgement result.
+"""
+
+
+ZeroArgFunctionHandler = Callable[[], Awaitable[Any]]
+"""Function handler that takes no arguments.
+
+.. deprecated:: 1.x.0
+    Use :data:`FlowFunctionHandler` (``(args, flow_manager)``) instead. Will be
+    removed in 2.0.0.
+
+Returns:
+    Any JSON-serializable value, or a :data:`ConsolidatedFunctionResult`
+    tuple to also specify the next node.
+"""
+
+LegacyFunctionHandler = Callable[[FlowArgs], Awaitable[Any]]
+"""Legacy function handler that only receives arguments.
+
+.. deprecated:: 1.x.0
+    Use :data:`FlowFunctionHandler` (``(args, flow_manager)``) instead. Will be
+    removed in 2.0.0.
+
+Args:
+    args: Dictionary of arguments from the function call.
+
+Returns:
+    Any JSON-serializable value, or a :data:`ConsolidatedFunctionResult`
+    tuple to also specify the next node.
+"""
+
+FlowFunctionHandler = Callable[[FlowArgs, "FlowManager"], Awaitable[Any]]
+"""Modern function handler that receives both arguments and flow_manager.
+
+Args:
+    args: Dictionary of arguments from the function call.
+    flow_manager: Reference to the FlowManager instance.
+
+Returns:
+    Any JSON-serializable value, or a :data:`ConsolidatedFunctionResult`
+    tuple to also specify the next node.
+"""
+
+
+FunctionHandler = ZeroArgFunctionHandler | LegacyFunctionHandler | FlowFunctionHandler
+"""Union type for function handlers supporting 0-arg, legacy, and modern patterns."""
+
+
+FlowsDirectFunction = Callable[..., Awaitable[ConsolidatedFunctionResult]]
+"""Type alias for "direct" functions with automatic metadata extraction.
+
+"Direct" functions have their definition automatically extracted from the
+function signature and docstring. This can be used in :data:`NodeConfig`
+directly, in lieu of a :class:`FlowsFunctionSchema` or function definition
+dict.
+
+Expected shape:
+
+.. code-block:: python
+
+    async def f(flow_manager: FlowManager, **params) -> ConsolidatedFunctionResult:
+        ...
+
+where ``**params`` are any named parameters described by the function's
+docstring.
+
+This is defined as ``Callable[..., ...]`` rather than a Protocol because
+Python's Protocol system cannot express "any concrete named-parameter list"
+against ``**kwargs: Any`` — a function with named params like ``llm: str``
+is not structurally compatible with a ``**kwargs: Any`` protocol signature.
+Runtime validation of the expected shape happens in
+:meth:`FlowsDirectFunctionWrapper.validate_function`.
+"""
 
 
 @dataclass
@@ -385,59 +451,6 @@ class FlowsDirectFunctionWrapper(BaseDirectFunctionWrapper):
             The result of the function call.
         """
         return await self.function(flow_manager=flow_manager, **args)
-
-
-class NodeConfig(TypedDict, total=False):
-    """Configuration for a single node in the flow.
-
-    Parameters:
-        task_messages: List of message dicts defining the current node's objectives.
-        name: Name of the node, useful for debug logging when returning a next node
-            from a "consolidated" function.
-        role_message: The bot's role/personality as a plain string, sent as the
-            LLM's system instruction via ``LLMUpdateSettingsFrame``. When
-            provided, the system instruction persists across node transitions
-            until a new node explicitly sets ``role_message`` again.
-        role_messages: Deprecated list-of-dicts format for the bot's role/personality.
-
-            .. deprecated:: 0.0.24
-                Use ``role_message`` (str) instead. Will be removed in 2.0.0.
-
-        functions: List of FlowsFunctionSchema definitions or direct functions
-            whose definitions are automatically extracted from their signatures.
-        pre_actions: Actions to execute before LLM inference.
-        post_actions: Actions to execute after LLM inference.
-        context_strategy: Strategy for updating context during transitions.
-        respond_immediately: Whether to run LLM inference as soon as the node is
-            set (default: True).
-
-    Example::
-
-        {
-            "role_message": "You are a helpful assistant...",
-            "task_messages": [
-                {
-                    "role": "developer",
-                    "content": "Ask the user for their name..."
-                }
-            ],
-            "functions": [...],
-            "pre_actions": [...],
-            "post_actions": [...],
-            "context_strategy": ContextStrategyConfig(strategy=ContextStrategy.APPEND),
-            "respond_immediately": true,
-        }
-    """
-
-    task_messages: Required[list[dict]]
-    name: str
-    role_message: str
-    role_messages: list[dict[str, Any]]
-    functions: list[FlowsFunctionSchema | FlowsDirectFunction]
-    pre_actions: list[ActionConfig]
-    post_actions: list[ActionConfig]
-    context_strategy: ContextStrategyConfig
-    respond_immediately: bool
 
 
 def get_or_generate_node_name(node_config: NodeConfig) -> str:

--- a/tests/test_flows_direct_functions.py
+++ b/tests/test_flows_direct_functions.py
@@ -10,7 +10,11 @@ from typing import Optional, TypedDict, Union
 
 from pipecat_flows.exceptions import InvalidFunctionError
 from pipecat_flows.manager import FlowManager
-from pipecat_flows.types import FlowsDirectFunctionWrapper, flows_direct_function
+from pipecat_flows.types import (
+    ConsolidatedFunctionResult,
+    FlowsDirectFunctionWrapper,
+    flows_direct_function,
+)
 
 """Tests for FlowsDirectFunction class."""
 
@@ -349,6 +353,39 @@ class TestFlowsDirectFunctionDecorator(unittest.TestCase):
         )
         self.assertFalse(func.cancel_on_interruption)
         self.assertEqual(func.timeout_secs, 15.5)
+
+
+class TestConsolidatedFunctionResult(unittest.TestCase):
+    """Regression tests for ``ConsolidatedFunctionResult`` resolvability."""
+
+    def test_get_type_hints_resolves_without_nodeconfig_import(self):
+        """Annotating a function with ``ConsolidatedFunctionResult`` should not require importing ``NodeConfig``.
+
+        Previously the alias was defined as ``tuple[Any, "NodeConfig | None"]``
+        with a string forward reference, which ``get_type_hints()`` resolves
+        against the user's module globals. Users who did not separately import
+        ``NodeConfig`` got ``NameError: name 'NodeConfig' is not defined`` —
+        which then surfaced from ``FlowManager._set_node`` and stalled the
+        flow. See https://github.com/pipecat-ai/pipecat-flows/issues/271.
+        """
+        from typing import get_type_hints
+
+        async def my_tool(flow_manager: FlowManager) -> ConsolidatedFunctionResult:
+            """Do something and optionally transition."""
+            return None, None
+
+        hints = get_type_hints(my_tool)
+        self.assertIn("return", hints)
+
+    def test_direct_function_wrapper_accepts_consolidated_return_type(self):
+        """``FlowsDirectFunctionWrapper`` introspects via ``get_type_hints`` internally."""
+
+        async def my_tool(flow_manager: FlowManager) -> ConsolidatedFunctionResult:
+            """Do something and optionally transition."""
+            return None, None
+
+        self.assertIsNone(FlowsDirectFunctionWrapper.validate_function(my_tool))
+        FlowsDirectFunctionWrapper(function=my_tool)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #271.

`ConsolidatedFunctionResult` is a public type alias users are expected to use as the return annotation of "direct" functions (per `FlowsDirectFunction` / `FlowsDirectFunctionWrapper`). In `1.1.0` it was defined as:

```python
# src/pipecat_flows/types.py
ConsolidatedFunctionResult = tuple[Any, "NodeConfig | None"]
```

The string forward reference exists because `NodeConfig` is defined later in the same file. When `BaseDirectFunctionWrapper` introspects a user-defined direct function, it calls `get_type_hints(func)`, which resolves string forward references against the **user's** module globals — not `pipecat_flows.types`. Unless the user separately imports `NodeConfig`, this raises:

```
NameError: name 'NodeConfig' is not defined
```

In practice the failure surfaces deep inside `FlowManager._set_node` and stalls the flow: the function call itself succeeds and the transition fires, but the next node never activates.

## Fix

Reorder `types.py` so `NodeConfig` is defined *before* `ConsolidatedFunctionResult`. The alias can then drop the string quotes:

```python
ConsolidatedFunctionResult = tuple[Any, NodeConfig | None]
```

Now the alias is fully resolved at module import time, so `get_type_hints()` on user code doesn't need to look up `NodeConfig` in the caller's globals.

`NodeConfig` retains string forward references for `FlowsFunctionSchema | FlowsDirectFunction` (which are still declared later in the file), but those references are only resolved by `get_type_hints(NodeConfig)`, which uses this module's globals — and the names do exist there.

A few other small definitions (`LegacyActionHandler`, `FlowActionHandler`, `ActionConfig`, `ContextStrategy`, `ContextStrategyConfig`) were moved up alongside `NodeConfig` because `NodeConfig` depends on them. The rest of the file is unchanged.

## Test plan

- [x] Added two regression tests in `tests/test_flows_direct_functions.py`:
  - `test_get_type_hints_resolves_without_nodeconfig_import` — runs the exact repro from the issue.
  - `test_direct_function_wrapper_accepts_consolidated_return_type` — verifies `FlowsDirectFunctionWrapper.validate_function` / construction succeed for a direct function annotated with `-> ConsolidatedFunctionResult`, since the wrapper internally calls `get_type_hints`.
- [x] `uv run pytest tests/` — all 74 tests pass.
- [x] `uv run ruff format --check .` and `uv run ruff check .` — clean.
- [x] Confirmed the minimal repro from the issue now succeeds without importing `NodeConfig`.