### PR TITLE
fix: propagate context reset to LLM service

### DIFF
--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -834,15 +834,15 @@ class FlowManager:
             messages.extend(task_messages)
 
             # For first node or RESET/RESET_WITH_SUMMARY strategy, use update frame
-            frame_type = (
-                LLMMessagesUpdateFrame
-                if self._current_node is None
+            if (
+                self._current_node is None
                 or update_config.strategy
                 in [ContextStrategy.RESET, ContextStrategy.RESET_WITH_SUMMARY]
-                else LLMMessagesAppendFrame
-            )
+            ):
+                frames.append(LLMMessagesUpdateFrame(messages=messages, run_llm=True))
+            else:
+                frames.append(LLMMessagesAppendFrame(messages=messages))
 
-            frames.append(frame_type(messages=messages))
             frames.append(LLMSetToolsFrame(tools=functions))
 
             await self._task.queue_frames(frames)

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -841,7 +841,7 @@ class FlowManager:
             ):
                 frames.append(LLMMessagesUpdateFrame(messages=messages, run_llm=True))
             else:
-                frames.append(LLMMessagesAppendFrame(messages=messages))
+                frames.append(LLMMessagesAppendFrame(messages=messages, run_llm=True))
 
             frames.append(LLMSetToolsFrame(tools=functions))
 


### PR DESCRIPTION
When using `ContextStrategy.RESET`, `FlowManager` sends an `LLMMessagesUpdateFrame`. However, it currently omits the `run_llm=True` flag. In the Pipecat pipeline, the `LLMContextAggregator` only pushes the updated context downstream if this flag is set. Consequently, the LLM service continues using its internal cached history, making the reset ineffective.

This PR sets `run_llm=True` on the update frame to ensure the cleared context is properly synchronized with the LLM service.