### PR TITLE
Add append_text_to_context for TTS actions; preserve initial-node context

### DIFF
--- a/changelog/281.added.md
+++ b/changelog/281.added.md
@@ -1,0 +1,1 @@
+- Added an `append_text_to_context` option to the `tts_say` and `end_conversation` actions, controlling whether the spoken text is written to the LLM context.

--- a/changelog/281.changed.2.md
+++ b/changelog/281.changed.2.md
@@ -1,0 +1,1 @@
+- ⚠️ The `tts_say` and `end_conversation` actions now append their spoken text to the LLM context by default (`append_text_to_context` defaults to `True`). Set `append_text_to_context=False` to opt out.

--- a/changelog/281.changed.md
+++ b/changelog/281.changed.md
@@ -1,0 +1,1 @@
+- ⚠️ The initial flow node now follows its context strategy (default `APPEND`) instead of always replacing the context. With the default strategy, context written before the node's first inference — for example by a `tts_say` pre-action — is now preserved rather than discarded. Set `context_strategy=RESET` on the initial node for the previous clean-slate behavior.

--- a/src/pipecat_flows/actions.py
+++ b/src/pipecat_flows/actions.py
@@ -303,7 +303,10 @@ class ActionManager:
         """Built-in handler for TTS actions.
 
         Args:
-            action: Action configuration containing 'text' to speak.
+            action: Action configuration dictionary. Required 'text' key with
+                the text to speak. Optional 'append_text_to_context' key (bool)
+                controlling whether the spoken text is appended to the LLM
+                context. Defaults to True.
         """
         text = action.get("text")
         if not text:
@@ -314,8 +317,13 @@ class ActionManager:
             # Mark that we're starting the action
             self._increment_ongoing_actions_count()
 
-            # Queue the action frame
-            await self._worker.queue_frame(TTSSpeakFrame(text=text))
+            # Queue the action frame. Default to appending the spoken text to the
+            # context; callers opt out with append_text_to_context=False.
+            await self._worker.queue_frame(
+                TTSSpeakFrame(
+                    text=text, append_to_context=action.get("append_text_to_context", True)
+                )
+            )
 
             # Queue a frame marking the end of the action
             await self._worker.queue_frame(ActionFinishedFrame())
@@ -331,14 +339,23 @@ class ActionManager:
 
         Args:
             action: Action configuration dictionary. Optional 'text' key for a
-                goodbye message.
+                goodbye message. Optional 'append_text_to_context' key (bool)
+                controlling whether that goodbye text is appended to the LLM
+                context. Defaults to True.
         """
         # Mark that we're starting the action
         self._increment_ongoing_actions_count()
 
         # Queue the action frames
         if action.get("text"):  # Optional goodbye message
-            await self._worker.queue_frame(TTSSpeakFrame(text=action["text"]))
+            # Default to appending the goodbye text to the context; callers opt
+            # out with append_text_to_context=False.
+            await self._worker.queue_frame(
+                TTSSpeakFrame(
+                    text=action["text"],
+                    append_to_context=action.get("append_text_to_context", True),
+                )
+            )
         await self._worker.queue_frame(EndFrame())
 
         # NOTE: there's no point queueing an ActionFinishedFrame here, since the previously-queued

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -874,11 +874,13 @@ class FlowManager:
             # Add task messages
             messages.extend(task_messages)
 
-            # For first node or RESET/RESET_WITH_SUMMARY strategy, use update frame
+            # Use an "update" (replace) frame for the RESET/RESET_WITH_SUMMARY
+            # strategies; otherwise append. (Note that even the first node follows
+            # the same rule: appending ensures any prior context contributions,
+            # such as by tts_say pre-actions, is preserved rather than replaced).
             frame_type = (
                 LLMMessagesUpdateFrame
-                if self._current_node is None
-                or update_config.strategy
+                if update_config.strategy
                 in [ContextStrategy.RESET, ContextStrategy.RESET_WITH_SUMMARY]
                 else LLMMessagesAppendFrame
             )

--- a/src/pipecat_flows/types.py
+++ b/src/pipecat_flows/types.py
@@ -115,7 +115,11 @@ class ActionConfig(TypedDict, total=False):
     Parameters:
         type: Action type identifier (e.g. "tts_say", "notify_slack").
         handler: Callable to handle the action.
-        text: Text for tts_say action.
+        text: Text to speak for the "tts_say" action, or the optional goodbye
+            message for the "end_conversation" action.
+        append_text_to_context: For the built-in TTS actions ("tts_say" and
+            "end_conversation"), whether the spoken ``text`` is appended to the
+            LLM context. Defaults to True.
 
     Note:
         Additional fields are allowed and passed to the handler.
@@ -124,6 +128,7 @@ class ActionConfig(TypedDict, total=False):
     type: Required[str]
     handler: LegacyActionHandler | FlowActionHandler
     text: str
+    append_text_to_context: bool
 
 
 class ContextStrategy(Enum):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -21,6 +21,7 @@ mocked dependencies for PipelineTask.
 
 import asyncio
 import unittest
+import warnings
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -29,6 +30,7 @@ from pipecat_flows.exceptions import ActionError
 from tests.test_helpers import (
     assert_end_frame_queued,
     assert_tts_speak_frames_queued,
+    get_queued_tts_speak_frames,
     make_mock_task,
 )
 
@@ -97,6 +99,77 @@ class TestActionManager(unittest.IsolatedAsyncioTestCase):
 
         # Verify EndFrame
         assert_end_frame_queued(self.mock_task)
+
+    async def test_tts_action_append_text_to_context(self):
+        """Test that tts_say maps append_text_to_context onto the TTSSpeakFrame."""
+        # Explicitly True
+        await self.action_manager.execute_actions(
+            [{"type": "tts_say", "text": "Hello", "append_text_to_context": True}]
+        )
+        frames = get_queued_tts_speak_frames(self.mock_task)
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0].append_to_context, True)
+
+        # Explicitly False
+        self.mock_task.queue_frame.reset_mock()
+        await self.action_manager.execute_actions(
+            [{"type": "tts_say", "text": "Hello", "append_text_to_context": False}]
+        )
+        frames = get_queued_tts_speak_frames(self.mock_task)
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0].append_to_context, False)
+
+        # Omitted: Flows applies its own default of True (and never passes None,
+        # so no append_to_context deprecation warning fires).
+        self.mock_task.queue_frame.reset_mock()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await self.action_manager.execute_actions([{"type": "tts_say", "text": "Hello"}])
+        frames = get_queued_tts_speak_frames(self.mock_task)
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0].append_to_context, True)
+        self.assertEqual(
+            [w for w in caught if "append_to_context" in str(w.message)],
+            [],
+            "Flows must not pass None to TTSSpeakFrame",
+        )
+
+    async def test_end_conversation_append_text_to_context(self):
+        """Test that end_conversation maps append_text_to_context onto its goodbye frame."""
+        # Explicitly False
+        await self.action_manager.execute_actions(
+            [{"type": "end_conversation", "text": "Goodbye!", "append_text_to_context": False}]
+        )
+        frames = get_queued_tts_speak_frames(self.mock_task)
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0].append_to_context, False)
+        assert_end_frame_queued(self.mock_task)
+
+        # Explicitly True
+        self.mock_task.queue_frame.reset_mock()
+        await self.action_manager.execute_actions(
+            [{"type": "end_conversation", "text": "Goodbye!", "append_text_to_context": True}]
+        )
+        frames = get_queued_tts_speak_frames(self.mock_task)
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0].append_to_context, True)
+
+        # Omitted: Flows applies its own default of True (and never passes None,
+        # so no append_to_context deprecation warning fires).
+        self.mock_task.queue_frame.reset_mock()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await self.action_manager.execute_actions(
+                [{"type": "end_conversation", "text": "Goodbye!"}]
+            )
+        frames = get_queued_tts_speak_frames(self.mock_task)
+        self.assertEqual(len(frames), 1)
+        self.assertIs(frames[0].append_to_context, True)
+        self.assertEqual(
+            [w for w in caught if "append_to_context" in str(w.message)],
+            [],
+            "Flows must not pass None to TTSSpeakFrame",
+        )
 
     async def test_function_actions(self):
         """Test executing function actions."""

--- a/tests/test_context_strategies.py
+++ b/tests/test_context_strategies.py
@@ -129,11 +129,13 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         )
         await flow_manager.initialize()
 
-        # First node should use UpdateFrame regardless of strategy
+        # Under the default (APPEND) strategy the first node appends, keeping any
+        # context already present.
         await flow_manager._set_node("first", self.sample_node)
         first_call = self.mock_task.queue_frames.call_args_list[0]
         first_frames = first_call[0][0]
-        self.assertTrue(any(isinstance(f, LLMMessagesUpdateFrame) for f in first_frames))
+        self.assertTrue(any(isinstance(f, LLMMessagesAppendFrame) for f in first_frames))
+        self.assertFalse(any(isinstance(f, LLMMessagesUpdateFrame) for f in first_frames))
 
         # Reset mock
         self.mock_task.queue_frames.reset_mock()
@@ -154,8 +156,11 @@ class TestContextStrategies(unittest.IsolatedAsyncioTestCase):
         )
         await flow_manager.initialize()
 
-        # Set initial node
+        # First node should use UpdateFrame under the RESET strategy
         await flow_manager._set_node("first", self.sample_node)
+        first_call = self.mock_task.queue_frames.call_args_list[0]
+        first_frames = first_call[0][0]
+        self.assertTrue(any(isinstance(f, LLMMessagesUpdateFrame) for f in first_frames))
         self.mock_task.queue_frames.reset_mock()
 
         # Second node should use UpdateFrame with RESET strategy

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,6 +19,17 @@ def assert_tts_speak_frames_queued(mock_task, expected_texts):
         )
 
 
+def get_queued_tts_speak_frames(mock_task):
+    """Return the TTSSpeakFrames queued on the mock task, in order."""
+    from pipecat.frames.frames import TTSSpeakFrame
+
+    return [
+        call[0][0]
+        for call in mock_task.queue_frame.call_args_list
+        if isinstance(call[0][0], TTSSpeakFrame)
+    ]
+
+
 def assert_end_frame_queued(mock_task):
     """Assert that an EndFrame was queued."""
     from pipecat.frames.frames import EndFrame

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -762,15 +762,15 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             settings_frames[0].delta.system_instruction, "You are a helpful assistant."
         )
 
-        # Verify UpdateFrame contains only task_messages (not role_messages)
-        update_frames = [f for f in first_frames if isinstance(f, LLMMessagesUpdateFrame)]
-        self.assertEqual(len(update_frames), 1)
-        self.assertEqual(update_frames[0].messages, first_node["task_messages"])
+        # Verify AppendFrame contains only task_messages (not role_messages)
+        append_frames = [f for f in first_frames if isinstance(f, LLMMessagesAppendFrame)]
+        self.assertEqual(len(append_frames), 1)
+        self.assertEqual(append_frames[0].messages, first_node["task_messages"])
 
-        # Verify frame ordering: LLMUpdateSettingsFrame before LLMMessagesUpdateFrame
+        # Verify frame ordering: LLMUpdateSettingsFrame before LLMMessagesAppendFrame
         settings_idx = first_frames.index(settings_frames[0])
-        update_idx = first_frames.index(update_frames[0])
-        self.assertLess(settings_idx, update_idx)
+        append_idx = first_frames.index(append_frames[0])
+        self.assertLess(settings_idx, append_idx)
 
         # Reset mock and set second node
         self.mock_task.queue_frames.reset_mock()
@@ -788,7 +788,11 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(append_frames[0].messages, second_node["task_messages"])
 
     async def test_frame_type_selection(self):
-        """Test that correct frame types are used based on node order."""
+        """Test that the context-update frame type follows the context strategy.
+
+        Under the default (APPEND) strategy, the context update appends for
+        every node.
+        """
         flow_manager = FlowManager(
             worker=self.mock_task,
             llm=self.mock_llm,
@@ -801,23 +805,23 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
             "functions": [],
         }
 
-        # First node should use UpdateFrame
+        # Under the default strategy the first node appends.
         await flow_manager.set_node_from_config(test_node)
         first_call = self.mock_task.queue_frames.call_args_list[0]  # Get first call
         first_frames = first_call[0][0]
         self.assertTrue(
-            any(isinstance(f, LLMMessagesUpdateFrame) for f in first_frames),
-            "First node should use UpdateFrame",
+            any(isinstance(f, LLMMessagesAppendFrame) for f in first_frames),
+            "First node should use AppendFrame under the default strategy",
         )
         self.assertFalse(
-            any(isinstance(f, LLMMessagesAppendFrame) for f in first_frames),
-            "First node should not use AppendFrame",
+            any(isinstance(f, LLMMessagesUpdateFrame) for f in first_frames),
+            "First node should not use UpdateFrame under the default strategy",
         )
 
         # Reset mock
         self.mock_task.queue_frames.reset_mock()
 
-        # Second node should use AppendFrame
+        # Subsequent node should also use AppendFrame
         await flow_manager.set_node_from_config(test_node)
         first_call = self.mock_task.queue_frames.call_args_list[0]  # Get first call
         second_frames = first_call[0][0]
@@ -1149,9 +1153,9 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         )
 
         # Verify messages frame contains only task_messages
-        update_frames = [f for f in first_frames if isinstance(f, LLMMessagesUpdateFrame)]
-        self.assertEqual(len(update_frames), 1)
-        self.assertEqual(update_frames[0].messages, node["task_messages"])
+        append_frames = [f for f in first_frames if isinstance(f, LLMMessagesAppendFrame)]
+        self.assertEqual(len(append_frames), 1)
+        self.assertEqual(append_frames[0].messages, node["task_messages"])
 
     async def test_role_messages_persist_across_reset(self):
         """Test that system instruction persists when a RESET node omits role_message."""
@@ -1237,10 +1241,10 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         settings_frames = [f for f in first_frames if isinstance(f, LLMUpdateSettingsFrame)]
         self.assertEqual(len(settings_frames), 0)
 
-        update_frames = [f for f in first_frames if isinstance(f, LLMMessagesUpdateFrame)]
-        self.assertEqual(len(update_frames), 1)
+        append_frames = [f for f in first_frames if isinstance(f, LLMMessagesAppendFrame)]
+        self.assertEqual(len(append_frames), 1)
         self.assertEqual(
-            update_frames[0].messages[0],
+            append_frames[0].messages[0],
             {"role": "developer", "content": "You are a helpful assistant."},
         )
 
@@ -1315,9 +1319,9 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(settings_frames), 0)
 
         # Legacy role_messages should be prepended to context messages
-        update_frames = [f for f in first_frames if isinstance(f, LLMMessagesUpdateFrame)]
-        self.assertEqual(len(update_frames), 1)
-        messages = update_frames[0].messages
+        append_frames = [f for f in first_frames if isinstance(f, LLMMessagesAppendFrame)]
+        self.assertEqual(len(append_frames), 1)
+        messages = append_frames[0].messages
         self.assertEqual(
             messages[0], {"role": "developer", "content": "You are a helpful assistant."}
         )


### PR DESCRIPTION
## Summary

A few related changes for how Pipecat Flows writes programmatically-generated TTS output to the LLM context.

1. The `tts_say` and `end_conversation` actions now append their spoken text to the LLM context by default (`append_text_to_context` defaults to `True`)
2. The initial flow node now follows its context strategy (default `APPEND`) instead of always replacing the context. With the default strategy, context written before the node's first inference — for example by a `tts_say` pre-action — is now preserved.
3. Added an `append_text_to_context` option to the `tts_say` and `end_conversation` actions, controlling whether the spoken text is written to the LLM context.

## Testing

`uv run pytest tests/` — all green against the released `pipecat-ai` (1.3.0) as well as the unreleased tip of the Pipecat `main` branch. Also validated live against a local example exercising `tts_say` as pre- and post-actions and `end_conversation`, toggling `append_text_to_context` across `True`/`False`/unset and printing the resulting context.
