### PR TITLE
fix(manager): scope LLMUpdateSettingsFrame to FlowManager's own LLM service

### DIFF
--- a/changelog/288.fixed.md
+++ b/changelog/288.fixed.md
@@ -1,0 +1,8 @@
+- Fixed ``FlowManager._update_llm_context`` pushing ``LLMUpdateSettingsFrame``
+  without ``service=self._llm``. The frame broadcasts to every ``LLMService``
+  on the bus, so in multi-worker setups a sibling worker's LLM picks up the
+  delta and adopts this worker's system instruction — causing the caller LLM
+  to be hijacked with the sub-bot persona during sub-bot activation. The
+  ``FlowManager`` already holds its own ``LLMService`` (``self._llm``), so the
+  scope is always available; the single-worker case is unchanged (the only
+  LLM on the bus is also ``self._llm``).

--- a/src/pipecat_flows/manager.py
+++ b/src/pipecat_flows/manager.py
@@ -772,8 +772,20 @@ class FlowManager:
 
             # New path: role_message as LLM system instruction (persists until changed)
             if role_message:
+                # ``service=self._llm`` scopes the delta to this FlowManager's
+                # own LLM service. Without it, ``LLMUpdateSettingsFrame``
+                # broadcasts to EVERY ``LLMService`` on the bus, so in
+                # multi-worker setups a sibling worker's LLM picks up the
+                # delta and adopts this worker's system instruction. The
+                # ``FlowManager`` always knows its own LLM (passed at the
+                # constructor and stored as ``self._llm``), so the scope is
+                # always available; the single-worker case is unchanged (the
+                # only LLM on the bus is also ``self._llm``).
                 frames.append(
-                    LLMUpdateSettingsFrame(delta=LLMSettings(system_instruction=role_message))
+                    LLMUpdateSettingsFrame(
+                        delta=LLMSettings(system_instruction=role_message),
+                        service=self._llm,
+                    )
                 )
 
             messages = []

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -787,6 +787,10 @@ class TestFlowManager(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             settings_frames[0].delta.system_instruction, "You are a helpful assistant."
         )
+        # The frame must be scoped to this FlowManager's own LLM service
+        # so peer LLMs on the bus (multi-worker setups) don't pick up the
+        # delta and adopt this worker's system instruction.
+        self.assertIs(settings_frames[0].service, self.mock_llm)
 
         # Verify AppendFrame contains only task_messages (not role_messages)
         append_frames = [f for f in first_frames if isinstance(f, LLMMessagesAppendFrame)]


### PR DESCRIPTION
``FlowManager._update_llm_context`` pushes ``LLMUpdateSettingsFrame(delta=LLMSettings(system_instruction=role_message))`` without a ``service=`` scope. The frame broadcasts to every ``LLMService`` on the bus.

In multi-worker setups this means a sibling worker's LLM picks up the delta and adopts this worker's system instruction. The user-visible symptom in our deployment: during sub-bot activation (``callBot`` / ``transferToBot`` patterns where multiple ``LLMWorker``s share a transport via ``BusBridgeProcessor``), the caller's ``LLMService`` got hijacked with the sub-bot persona, then the caller was re-activated and started responding as if it were the sub-bot. Looping ``endCall`` on the wrong worker, etc.

The ``FlowManager`` already holds its own ``LLMService`` (``self._llm``, passed at construction), so the scope is always available. Single-worker behaviour is unchanged: the only LLM on the bus is also ``self._llm`` and matches.

```python
LLMUpdateSettingsFrame(
    delta=LLMSettings(system_instruction=role_message),
    service=self._llm,   # ← scope to own LLM
)
```

Test ``test_role_message_inheritance`` extended to assert ``settings_frames[0].service is self.mock_llm`` (passes with fix, fails on main).

Downstream context: we worked around this with a config-side refactor (migrating all sub-bot goodbye nodes to ``type:'action'`` LLM-free, which bypasses ``_set_node``'s frame push). That keeps the leak away from the bus but doesn't fix the root cause; this PR does.